### PR TITLE
FIx minimum Flask and Django versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ dash-html-components
 dash-renderer
 plotly
 dpd-components
+
+Flask>=1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ dash-renderer
 plotly
 dpd-components
 
+Django>=2
 Flask>=1.0.2

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ setup(
                         'dash-html-components',
                         'dash-renderer',
                         'dpd-components',
-                        'Django>=2',],
+                        'Django>=2',
+                        'Flask>=1.0.2'],
     python_requires=">=3.5",
     )
 


### PR DESCRIPTION
Fix minimum version of Flask (1.0.2) and Django (2) in both requirements and setup.py files.

Addresses #31 which is assumed to be due to use of older versions of Flask.
