### PR TITLE
added 3 lines to DjangoDash to implement this feature

### DIFF
--- a/django_plotly_dash/dash_wrapper.py
+++ b/django_plotly_dash/dash_wrapper.py
@@ -76,6 +76,7 @@ class DjangoDash:
     def __init__(self, name=None, serve_locally=False,
                  expanded_callbacks=False,
                  add_bootstrap_links=False,
+                 suppress_callback_exceptions=False,
                  **kwargs): # pylint: disable=unused-argument
         if name is None:
             global uid_counter # pylint: disable=global-statement
@@ -94,6 +95,7 @@ class DjangoDash:
 
         self._expanded_callbacks = expanded_callbacks
         self._serve_locally = serve_locally
+        self._suppress_callback_exceptions = suppress_callback_exceptions
 
         if add_bootstrap_links:
             from bootstrap4.bootstrap import css_url
@@ -147,6 +149,7 @@ class DjangoDash:
                          serve_locally=self._serve_locally)
 
         rd.layout = self.layout
+        rd.config['suppress_callback_exceptions'] = self._suppress_callback_exceptions
 
         for cb, func in self._callback_sets:
             rd.callback(**cb)(func)


### PR DESCRIPTION
I added 3 lines of code to the DjangoDash class in dash_wrapper.py allowing the use of suppressing callback exceptions as per Dash. This addresses #36 .

On a side note, although this can currently put developers in debugging hell, there are some upcoming [updates to the Dash renderer](https://github.com/plotly/dash/pull/340), which should make it much easier to build more complex apps.
