### PR TITLE
added requirements for conda environments using .yaml files. Most of …

### DIFF
--- a/dev_requirements.yaml
+++ b/dev_requirements.yaml
@@ -1,0 +1,23 @@
+name: dpd
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - pandas
+  - pylint
+  - pytest>=3.6
+  - pytest-cov
+  - pytz
+  - redis
+  - twine
+  - twisted
+  - hiredis
+  - pip:
+    - channels>=2.0
+    - channels-redis
+    - daphne
+    - django-bootstrap4
+    - django-redis
+    - grip
+    - pytest-django
+    - sphinx-autobuild

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,0 +1,14 @@
+name: dpd
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - django>=2.0
+  - flask>=1
+  - pip:
+    - dash
+    - dash-core-components
+    - dash-html-components
+    - dash-renderer
+    - plotly
+    - dpd-components


### PR DESCRIPTION
…the packages can be installed interchangeably between pip and conda except for packages like 'hiredis', 'daphne' and 'pandas', which are packages (or rely on packages) with external dependencies that are likely to cause newbies problems on Windows. If these .yaml files work on windows, my assumption is that they are fine on every other system.