### PR TITLE
Make static finders handle case of missing settings gracefully

### DIFF
--- a/django_plotly_dash/finders.py
+++ b/django_plotly_dash/finders.py
@@ -50,7 +50,12 @@ class DashComponentFinder(BaseFinder):
 
         self.ignore_patterns = ["*.py", "*.pyc",]
 
-        for component_name in settings.PLOTLY_COMPONENTS:
+        try:
+            components = settings.PLOTLY_COMPONENTS
+        except:
+            components = []
+
+        for component_name in components:
 
             module = importlib.import_module(component_name)
             path_directory = os.path.dirname(module.__file__)


### PR DESCRIPTION
Handle the case of a missing settings variable containing the list of dash components to include when searching for static files.
 