### PR TITLE
Csrf middleware

### DIFF
--- a/demo/demo/bootstrap_app.py
+++ b/demo/demo/bootstrap_app.py
@@ -57,7 +57,7 @@ dis.layout = html.Div(
     [dash.dependencies.Input('danger-alert', 'children'),
     dash.dependencies.Input('csrfmiddlewaretoken', 'value'),]
     )
-def session_demo_danger_callback(da_children, session_state=None, **kwargs):
+def session_demo_danger_callback(da_children, token, session_state=None, **kwargs):
     'Update output based just on state'
     if not session_state:
         return "Session state not yet available"

--- a/demo/demo/bootstrap_app.py
+++ b/demo/demo/bootstrap_app.py
@@ -23,6 +23,7 @@ SOFTWARE.
 '''
 
 import dash
+import dash_core_components as dcc
 import dash_bootstrap_components as dbc
 import dash_html_components as html
 
@@ -42,7 +43,8 @@ dis = DjangoDash("DjangoSessionState",
                  add_bootstrap_links=True)
 
 dis.layout = html.Div(
-    [
+    [   
+        dcc.Input(id='csrfmiddlewaretoken', style={'display': 'hidden'}, value=''),
         dbc.Alert("This is an alert", id="base-alert", color="primary"),
         dbc.Alert(children="Danger", id="danger-alert", color="danger"),
         dbc.Button("Update session state", id="update-button", color="warning"),
@@ -52,7 +54,8 @@ dis.layout = html.Div(
 #pylint: ignore=unused-argument
 @dis.expanded_callback(
     dash.dependencies.Output("base-alert", 'children'),
-    [dash.dependencies.Input('danger-alert', 'children'),]
+    [dash.dependencies.Input('danger-alert', 'children'),
+    dash.dependencies.Input('csrfmiddlewaretoken', 'value'),]
     )
 def session_demo_danger_callback(da_children, session_state=None, **kwargs):
     'Update output based just on state'
@@ -64,9 +67,10 @@ def session_demo_danger_callback(da_children, session_state=None, **kwargs):
 #pylint: ignore=unused-argument
 @dis.expanded_callback(
     dash.dependencies.Output("danger-alert", 'children'),
-    [dash.dependencies.Input('update-button', 'n_clicks'),]
+    [dash.dependencies.Input('update-button', 'n_clicks'),
+    dash.dependencies.Input('csrfmiddlewaretoken', 'value'),]
     )
-def session_demo_alert_callback(n_clicks, session_state=None, **kwargs):
+def session_demo_alert_callback(n_clicks, csrftoken, session_state=None, **kwargs):
     'Output text based on both app state and session state'
     if session_state is None:
         raise NotImplementedError("Cannot handle a missing session state")

--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -48,7 +48,7 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
+    'django_plotly_dash.middleware.DPDCsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
 
@@ -134,6 +134,8 @@ PLOTLY_DASH = {
     "view_decorator" : None, # Specify a function to be used to wrap each of the dpd view functions
 
     "cache_arguments" : True, # True for cache, False for session-based argument propagation
+
+    "enable_anti_csrf": True, # Set to True if wanting to use Django CSRF Token framework as part of Dash
     }
 
 # Static files (CSS, JavaScript, Images)

--- a/django_plotly_dash/dash_wrapper.py
+++ b/django_plotly_dash/dash_wrapper.py
@@ -341,7 +341,6 @@ class WrappedDash(Dash):
                 if r is None:
                     r = self.walk_tree_and_replace(v, overrides)
                 response[k] = r
-                print("Response: %s" %(str(response[k])))
             return response
         if isinstance(data, list):
             # process each entry in turn and return

--- a/django_plotly_dash/dash_wrapper.py
+++ b/django_plotly_dash/dash_wrapper.py
@@ -323,16 +323,25 @@ class WrappedDash(Dash):
             replacements = {}
             # look for id entry
             thisID = data.get('id', None)
+
             if thisID is not None:
                 replacements = overrides.get(thisID, None) if overrides else None
+
                 if not replacements:
                     replacements = self._replacements.get(thisID, {})
+
             # walk all keys and replace if needed
             for k, v in data.items():
                 r = replacements.get(k, None)
+
+                # if the element is csrfmiddlewaretoken then replace value:
+                if thisID == 'csrfmiddlewaretoken' and k == 'value':
+                    r = self._csrfmiddlewaretoken
+                    
                 if r is None:
                     r = self.walk_tree_and_replace(v, overrides)
                 response[k] = r
+                print("Response: %s" %(str(response[k])))
             return response
         if isinstance(data, list):
             # process each entry in turn and return

--- a/django_plotly_dash/middleware.py
+++ b/django_plotly_dash/middleware.py
@@ -26,6 +26,9 @@ SOFTWARE.
 '''
 
 #pylint: disable=too-few-public-methods
+from django.conf import settings
+from django.middleware.csrf import CsrfViewMiddleware, _sanitize_token, _compare_salted_tokens, get_token
+import json
 
 class EmbeddedHolder:
     'Hold details of embedded content from processing a view'
@@ -98,3 +101,126 @@ class BaseMiddleware:
         response = request.dpd_content_handler.adjust_response(response)
 
         return response
+
+
+class DPDCsrfViewMiddleware(CsrfViewMiddleware):
+
+    def process_view(self, request, callback, callback_args, callback_kwargs):
+        if getattr(request, 'csrf_processing_done', False):
+            return None
+
+        # Wait until request.META["CSRF_COOKIE"] has been manipulated before
+        # bailing out, so that get_token still works
+        if getattr(callback, 'csrf_exempt', False):
+            return None
+
+        # Assume that anything not defined as 'safe' by RFC7231 needs protection
+        if request.method not in ('GET', 'HEAD', 'OPTIONS', 'TRACE'):
+            if getattr(request, '_dont_enforce_csrf_checks', False):
+                # Mechanism to turn off CSRF checks for test suite.
+                # It comes after the creation of CSRF cookies, so that
+                # everything else continues to work exactly the same
+                # (e.g. cookies are sent, etc.), but before any
+                # branches that call reject().
+                return self._accept(request)
+
+            if request.is_secure():
+                # Suppose user visits http://example.com/
+                # An active network attacker (man-in-the-middle, MITM) sends a
+                # POST form that targets https://example.com/detonate-bomb/ and
+                # submits it via JavaScript.
+                #
+                # The attacker will need to provide a CSRF cookie and token, but
+                # that's no problem for a MITM and the session-independent
+                # secret we're using. So the MITM can circumvent the CSRF
+                # protection. This is true for any HTTP connection, but anyone
+                # using HTTPS expects better! For this reason, for
+                # https://example.com/ we need additional protection that treats
+                # http://example.com/ as completely untrusted. Under HTTPS,
+                # Barth et al. found that the Referer header is missing for
+                # same-domain requests in only about 0.2% of cases or less, so
+                # we can use strict Referer checking.
+                referer = request.META.get('HTTP_REFERER')
+                if referer is None:
+                    return self._reject(request, REASON_NO_REFERER)
+
+                referer = urlparse(referer)
+
+                # Make sure we have a valid URL for Referer.
+                if '' in (referer.scheme, referer.netloc):
+                    return self._reject(request, REASON_MALFORMED_REFERER)
+
+                # Ensure that our Referer is also secure.
+                if referer.scheme != 'https':
+                    return self._reject(request, REASON_INSECURE_REFERER)
+
+                # If there isn't a CSRF_COOKIE_DOMAIN, require an exact match
+                # match on host:port. If not, obey the cookie rules (or those
+                # for the session cookie, if CSRF_USE_SESSIONS).
+                good_referer = (
+                    settings.SESSION_COOKIE_DOMAIN
+                    if settings.CSRF_USE_SESSIONS
+                    else settings.CSRF_COOKIE_DOMAIN
+                )
+                if good_referer is not None:
+                    server_port = request.get_port()
+                    if server_port not in ('443', '80'):
+                        good_referer = '%s:%s' % (good_referer, server_port)
+                else:
+                    try:
+                        # request.get_host() includes the port.
+                        good_referer = request.get_host()
+                    except DisallowedHost:
+                        pass
+
+                # Create a list of all acceptable HTTP referers, including the
+                # current host if it's permitted by ALLOWED_HOSTS.
+                good_hosts = list(settings.CSRF_TRUSTED_ORIGINS)
+                if good_referer is not None:
+                    good_hosts.append(good_referer)
+
+                if not any(is_same_domain(referer.netloc, host) for host in good_hosts):
+                    reason = REASON_BAD_REFERER % referer.geturl()
+                    return self._reject(request, reason)
+
+            csrf_token = request.META.get('CSRF_COOKIE')
+            if csrf_token is None:
+                # No CSRF cookie. For POST requests, we insist on a CSRF cookie,
+                # and in this way we can avoid all CSRF attacks, including login
+                # CSRF.
+                return self._reject(request, REASON_NO_CSRF_COOKIE)
+
+            print("App name:")
+            print(request.resolver_match.app_name)
+
+            # Check non-cookie token for match.
+            request_csrf_token = ""
+            if request.method == "POST":
+                try:
+                    request_csrf_token = request.POST.get('csrfmiddlewaretoken', '')
+                except IOError:
+                    # Handle a broken connection before we've completed reading
+                    # the POST data. process_view shouldn't raise any
+                    # exceptions, so we'll ignore and serve the user a 403
+                    # (assuming they're still listening, which they probably
+                    # aren't because of the error).
+                    pass
+
+            if request_csrf_token == "":
+                # Fall back to X-CSRFToken, to make things easier for AJAX,
+                # and possible for PUT/DELETE.
+                request_csrf_token = request.META.get(settings.CSRF_HEADER_NAME, '')
+
+            if request_csrf_token == "undefined" or "" :
+                import json
+                body = json.loads(request.body.decode('utf-8'))
+                for i in body['inputs']:
+                    if i['id'] == 'csrfmiddlewaretoken':
+                        request_csrf_token = i['value']
+
+
+            request_csrf_token = _sanitize_token(request_csrf_token)
+            if not _compare_salted_tokens(request_csrf_token, csrf_token):
+                return self._reject(request, REASON_BAD_TOKEN)
+
+        return self._accept(request)

--- a/django_plotly_dash/urls.py
+++ b/django_plotly_dash/urls.py
@@ -25,13 +25,14 @@ SOFTWARE.
 # pylint: disable = unused-import
 
 from django.urls import path
-from django.views.decorators.csrf import csrf_exempt
 
 from .views import routes, layout, dependencies, update, main_view, component_suites, component_component_suites
 
 from .app_name import app_name, main_view_label
 
 from .access import process_view_function
+
+from .util import check_csrf_exempt
 
 urlpatterns = []
 
@@ -44,7 +45,7 @@ for base_type, args, name_prefix, url_ending, name_suffix in [('instance', {}, '
     for url_part, view_function, name, url_suffix in [('_dash-routes', routes, 'routes', '', ),
                                                       ('_dash-layout', layout, 'layout', '', ),
                                                       ('_dash-dependencies', dependencies, 'dependencies', '', ),
-                                                      ('_dash-update-component', csrf_exempt(update), 'update-component', '', ),
+                                                      ('_dash-update-component', check_csrf_exempt(update), 'update-component', '', ),
                                                       ('', main_view, main_view_label, '', ),
                                                       ('_dash-component-suites', component_suites, 'component-suites', '/<slug:component>/<resource>', ),
                                                       ('_dash-component-suites', component_component_suites, 'component-component-suites', '/<slug:component>/_components/<resource>', ),

--- a/django_plotly_dash/util.py
+++ b/django_plotly_dash/util.py
@@ -27,6 +27,7 @@ import uuid
 
 from django.conf import settings
 from django.core.cache import cache
+from django.views.decorators.csrf import csrf_exempt
 
 def _get_settings():
     try:
@@ -95,3 +96,17 @@ def get_initial_arguments(request, cache_id=None):
         return cache.get(cache_id)
 
     return request.session[cache_id]
+
+def csrf_enabled():
+    'Return true if csrf protection enabled'
+    return _get_settings().get('enable_anti_csrf', False)
+
+def check_csrf_exempt(view_function, **kwargs):
+    'Check if csrf_enabled. If not, use csrf exempt on update function'
+
+    if not csrf_enabled():
+        return csrf_exempt(view_function, **kwargs)
+
+    return view_function
+
+

--- a/django_plotly_dash/views.py
+++ b/django_plotly_dash/views.py
@@ -30,6 +30,8 @@ from django.http import HttpResponse, HttpResponseRedirect
 
 from .models import DashApp
 from .util import get_initial_arguments
+from django.middleware.csrf import get_token
+
 
 def routes(*args, **kwargs):
     'Return routes'
@@ -51,13 +53,15 @@ def layout(request, ident, stateless=False, cache_id=None, **kwargs):
 
     view_func = app.locate_endpoint_function('dash-layout')
     resp = view_func()
+    
+    # get the token upon request of the layout
+    app._csrfmiddlewaretoken = get_token(request)
 
     initial_arguments = get_initial_arguments(request, cache_id)
 
     response_data, mimetype = app.augment_initial_layout(resp, initial_arguments)
     return HttpResponse(response_data,
                         content_type=mimetype)
-
 def update(request, ident, stateless=False, **kwargs):
     'Generate update json response'
     dash_app, app = DashApp.locate_item(ident, stateless)


### PR DESCRIPTION
This is a first pass at implementing middleware and is intended to serve only as a reference for my question in #104.

I would like to wrap each callback to include a CSRF token as an input.

The method is currently demo'd in Demo-eight but requires manual insertion of a token in to the initial app layout and to each input in the app. 

@GibbsConsulting  are you able to recommend a function / functions for me to look at in order to best achieve automatic insertion of a token?