### PR TITLE
Upgrade ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 # Travis CI
+dist: xenial
 language: python
 
 python:

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,7 +1,7 @@
 channels>=2.0
 channels-redis
 daphne
-Django>=2.0,<2.2
+Django>=2.0,<2.3
 django-bootstrap4
 django-redis
 dpd-static-support

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ dpd-components
 
 dash-bootstrap-components
 
-Django>=2,<2.2
+Django>=2,<2.3
 Flask>=1.0.2


### PR DESCRIPTION
This may require a
```
before_install:
    apt-get install sqlite3
```
section in `.travis.yml` if sqlite3 is not pre-installed in the base xenial image. I leave it out for now so. that the Travis tests can run on me opening this PR.