### PR TITLE
Increase version number to 0.9.10

### DIFF
--- a/django_plotly_dash/version.py
+++ b/django_plotly_dash/version.py
@@ -23,4 +23,4 @@ SOFTWARE.
 
 '''
 
-__version__ = "0.9.9"
+__version__ = "0.9.10"


### PR DESCRIPTION
New prerelease 0.9.10

This version should work with newer versions of underlying packages by handling alternative formats for json responses.
