### PR TITLE
Handle case of missing dash.fingerprint module

### DIFF
--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -27,3 +27,5 @@ Thanks to the following people:
 [dwinston](https://github.com/dwinston)
 
 [gianlucasalvato](https://github.com/gianlucasalvato)
+
+[tiagoslg](https://https://github.com/tiagoslg)

--- a/django_plotly_dash/views.py
+++ b/django_plotly_dash/views.py
@@ -28,7 +28,14 @@ import json
 
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import redirect
-from dash.fingerprint import check_fingerprint
+
+try:
+    from dash.fingerprint import check_fingerprint
+except:
+    # check_fingerprint not available, fake it
+    def check_fingerprint(resource):
+        return resource, None
+
 
 from .models import DashApp
 from .util import get_initial_arguments, static_path


### PR DESCRIPTION
Dash now has a fingerprint module, and dpd has been updated to use it. See #187 

This PR wraps the import of the module so that older dash versions without the module can still be used.
