### PR TITLE
Add handling of multiple return values from callbacks

### DIFF
--- a/demo/demo/plotly_apps.py
+++ b/demo/demo/plotly_apps.py
@@ -327,16 +327,23 @@ multiple_callbacks.layout = html.Div([
                    value='red'
                    ),
     html.Div(id="output-one"),
-    html.Div(id="output-two")
+    html.Div(id="output-two"),
+    html.Div(id="output-three")
     ])
 
 @multiple_callbacks.callback(
-    dash.dependencies.Output('output-one', 'children'),
+    [dash.dependencies.Output('output-one', 'children'),
+     dash.dependencies.Output('output-two', 'children'),
+     dash.dependencies.Output('output-three', 'children')
+     ],
     [dash.dependencies.Input('button','n_clicks'),
      dash.dependencies.Input('dropdown-color','value'),
      ])
 def multiple_callbacks_one(button_clicks, color_choice):
-    return "Output 1: %s %s" % (button_clicks, color_choice)
+    return ("Output 1: %s %s" % (button_clicks, color_choice),
+            "Output 2: %s %s" % (color_choice, button_clicks),
+            "Output 3: %s %s" % (button_clicks, color_choice),
+            )
 
 
 multiple_callbacks = DjangoDash("MultipleCallbackValuesExpanded")
@@ -349,14 +356,21 @@ multiple_callbacks.layout = html.Div([
                    value='red'
                    ),
     html.Div(id="output-one"),
-    html.Div(id="output-two")
+    html.Div(id="output-two"),
+    html.Div(id="output-three")
     ])
 
 @multiple_callbacks.expanded_callback(
-    dash.dependencies.Output('output-one', 'children'),
+    [dash.dependencies.Output('output-one', 'children'),
+     dash.dependencies.Output('output-two', 'children'),
+     dash.dependencies.Output('output-three', 'children')
+     ],
     [dash.dependencies.Input('button','n_clicks'),
      dash.dependencies.Input('dropdown-color','value'),
      ])
 def multiple_callbacks_two(button_clicks, color_choice, **kwargs):
-    return "Output 1: %s %s [%s]" % (button_clicks, color_choice, kwargs)
+    return ["Output 1: %s %s" % (button_clicks, color_choice),
+            "Output 2: %s %s" % (button_clicks, color_choice),
+            "Output 3: %s %s [%s]" % (button_clicks, color_choice, kwargs)
+            ]
 

--- a/demo/demo/plotly_apps.py
+++ b/demo/demo/plotly_apps.py
@@ -316,3 +316,11 @@ localState = DjangoDash("LocalState",
 localState.layout = html.Div([html.Img(src=localState.get_asset_url('image_one.png')),
                               html.Img(src='assets/image_two.png'),
                               ])
+
+multiple_callbacks = DjangoDash("MultipleCallbackValues")
+
+multiple_callbacks.layout = html.Div([
+    html.Button("PRESS ME",
+                id="button"),
+    ])
+

--- a/demo/demo/plotly_apps.py
+++ b/demo/demo/plotly_apps.py
@@ -320,7 +320,43 @@ localState.layout = html.Div([html.Img(src=localState.get_asset_url('image_one.p
 multiple_callbacks = DjangoDash("MultipleCallbackValues")
 
 multiple_callbacks.layout = html.Div([
-    html.Button("PRESS ME",
+    html.Button("Press Me",
                 id="button"),
+    dcc.RadioItems(id='dropdown-color',
+                   options=[{'label': c, 'value': c.lower()} for c in ['Red', 'Green', 'Blue']],
+                   value='red'
+                   ),
+    html.Div(id="output-one"),
+    html.Div(id="output-two")
     ])
+
+@multiple_callbacks.callback(
+    dash.dependencies.Output('output-one', 'children'),
+    [dash.dependencies.Input('button','n_clicks'),
+     dash.dependencies.Input('dropdown-color','value'),
+     ])
+def multiple_callbacks_one(button_clicks, color_choice):
+    return "Output 1: %s %s" % (button_clicks, color_choice)
+
+
+multiple_callbacks = DjangoDash("MultipleCallbackValuesExpanded")
+
+multiple_callbacks.layout = html.Div([
+    html.Button("Press Me",
+                id="button"),
+    dcc.RadioItems(id='dropdown-color',
+                   options=[{'label': c, 'value': c.lower()} for c in ['Red', 'Green', 'Blue']],
+                   value='red'
+                   ),
+    html.Div(id="output-one"),
+    html.Div(id="output-two")
+    ])
+
+@multiple_callbacks.expanded_callback(
+    dash.dependencies.Output('output-one', 'children'),
+    [dash.dependencies.Input('button','n_clicks'),
+     dash.dependencies.Input('dropdown-color','value'),
+     ])
+def multiple_callbacks_two(button_clicks, color_choice, **kwargs):
+    return "Output 1: %s %s [%s]" % (button_clicks, color_choice, kwargs)
 

--- a/demo/demo/scaffold.py
+++ b/demo/demo/scaffold.py
@@ -3,6 +3,8 @@
 from django_plotly_dash import DjangoDash
 from django.utils.module_loading import import_string
 
+from demo.plotly_apps import multiple_callbacks
+
 def stateless_app_loader(app_name):
 
     # Load a stateless app

--- a/demo/demo/templates/demo_ten.html
+++ b/demo/demo/templates/demo_ten.html
@@ -1,0 +1,26 @@
+{%extends "base.html"%}
+{%load plotly_dash%}
+
+{%block title%}Demo Ten - Multiple Callback Values{%endblock%}
+
+{%block content%}
+<h1>Multiple Callback Values</h1>
+<p>
+  Both standard and extended callbacks can return multiple responses. This example instantiates an example
+  application that uses multiple return values for both types of callback.
+</p>
+<div class="card bg-light border-dark">
+  <div class="card-body">
+    <p><span>{</span>% load plotly_dash %}</p>
+    <p><span>{</span>% plotly_app slug="multiple-callback-values" ratio=0.3 %}</p>
+  </div>
+</div>
+<p>
+</p>
+<div class="card border-dark">
+  <div class="card-body">
+    {%plotly_app slug="multiple-callback-values-1" ratio=0.3 %}
+  </div>
+</div>
+<p></p>
+{%endblock%}

--- a/demo/demo/templates/demo_ten.html
+++ b/demo/demo/templates/demo_ten.html
@@ -6,20 +6,27 @@
 {%block content%}
 <h1>Multiple Callback Values</h1>
 <p>
-  Both standard and extended callbacks can return multiple responses. This example instantiates an example
-  application that uses multiple return values for both types of callback.
+  Both standard and extended callbacks can return multiple responses. This example instantiates
+  two example applications that use multiple return values for both types of callback.
 </p>
 <div class="card bg-light border-dark">
   <div class="card-body">
     <p><span>{</span>% load plotly_dash %}</p>
-    <p><span>{</span>% plotly_app slug="multiple-callback-values" ratio=0.3 %}</p>
+    <p><span>{</span>% plotly_app slug="multiple-callback-values" ratio=0.2 %}</p>
+    <p><span>{</span>% plotly_app slug="multiple-callback-values-expanded" ratio=0.2 %}</p>
   </div>
 </div>
 <p>
 </p>
 <div class="card border-dark">
   <div class="card-body">
-    {%plotly_app slug="multiple-callback-values-1" ratio=0.3 %}
+    {%plotly_app slug="multiple-callback-values-1" ratio=0.2 %}
+  </div>
+</div>
+<p></p>
+<div class="card border-dark">
+  <div class="card-body">
+    {%plotly_app slug="multiple-callback-values-expanded" ratio=0.2 %}
   </div>
 </div>
 <p></p>

--- a/demo/demo/templates/index.html
+++ b/demo/demo/templates/index.html
@@ -16,5 +16,6 @@
     <li><a class="btn btn-primary btnspace" href="{%url "demo-seven"%}">Demo Seven</a> - dash-bootstrap-components example</li>
     <li><a class="btn btn-primary btnspace" href="{%url "demo-eight"%}">Demo Eight</a> - Django session state example</li>
     <li><a class="btn btn-primary btnspace" href="{%url "demo-nine"%}">Demo Nine</a> - local serving of assets</li>
+    <li><a class="btn btn-primary btnspace" href="{%url "demo-ten"%}">Demo Ten</a> - callback multiple return values</li>
   </ul>
 {%endblock%}

--- a/demo/demo/urls.py
+++ b/demo/demo/urls.py
@@ -45,6 +45,7 @@ urlpatterns = [
     url('^demo-seven', TemplateView.as_view(template_name='demo_seven.html'), name="demo-seven"),
     url('^demo-eight', session_state_view, {'template_name':'demo_eight.html'}, name="demo-eight"),
     url('^demo-nine', TemplateView.as_view(template_name='demo_nine.html'), name="demo-nine"),
+    url('^demo-ten', TemplateView.as_view(template_name='demo_ten.html'), name="demo-ten"),
     url('^admin/', admin.site.urls),
     url('^django_plotly_dash/', include('django_plotly_dash.urls')),
 

--- a/django_plotly_dash/dash_wrapper.py
+++ b/django_plotly_dash/dash_wrapper.py
@@ -509,6 +509,9 @@ class WrappedDash(Dash):
                 # Multiple outputs
                 outputs = output[2:-2].split('...')
                 target_id = output
+                # Special case of a single output
+                if len(outputs) == 1:
+                    target_id = output[2:-2]
         except:
             pass
 

--- a/django_plotly_dash/migrations/0002_add_examples.py
+++ b/django_plotly_dash/migrations/0002_add_examples.py
@@ -61,6 +61,17 @@ def addExamples(apps, schema_editor):
 
     da3.save()
 
+    sa4 = StatelessApp(app_name="MultipleCallbackValues",
+                       slug="multiple-callback-values")
+
+    sa4.save()
+
+    da4 = DashApp(stateless_app=sa4,
+                  instance_name="Multiple Callback Values Example 1",
+                  slug="multiple-callback-values-1")
+
+    da4.save()
+
 
 def remExamples(apps, schema_editor):
 

--- a/django_plotly_dash/migrations/0002_add_examples.py
+++ b/django_plotly_dash/migrations/0002_add_examples.py
@@ -72,6 +72,17 @@ def addExamples(apps, schema_editor):
 
     da4.save()
 
+    sa5 = StatelessApp(app_name="MultipleCallbackValuesExpanded",
+                       slug="multiple-callback-values-exapnded")
+
+    sa5.save()
+
+    da5 = DashApp(stateless_app=sa5,
+                  instance_name="Multiple Callback Values Example 2",
+                  slug="multiple-callback-values-expanded")
+
+    da5.save()
+
 
 def remExamples(apps, schema_editor):
 

--- a/django_plotly_dash/tests.py
+++ b/django_plotly_dash/tests.py
@@ -182,7 +182,6 @@ def test_injection_updating_multiple_callbacks(client):
              'value':'purple-ish yellow with a hint of greeny orange'},
                                                          ]}), content_type="application/json")
 
-        print(response.content)
         assert response.status_code == 200
 
         resp = json.loads(response.content.decode('utf-8'))
@@ -217,6 +216,18 @@ def test_injection_updating(client):
 
         # New variant of output has a string used to name the properties
         response = client.post(url, json.dumps({'output':'test-output-div.children',
+                                                'inputs':[{'id':'my-dropdown1',
+                                                           'property':'value',
+                                                           'value':'TestIt'},
+                                                         ]}), content_type="application/json")
+
+        rStart = b'{"response": {"props": {"children":'
+
+        assert response.content[:len(rStart)] == rStart
+        assert response.status_code == 200
+
+        # Second variant has a single-entry mulitple property output 
+        response = client.post(url, json.dumps({'output':'..test-output-div.children..',
                                                 'inputs':[{'id':'my-dropdown1',
                                                            'property':'value',
                                                            'value':'TestIt'},


### PR DESCRIPTION
Permit multiple return values from callbacks.
Add an example demonstrating use of multiple return values.
Fix up storage of callback return values in ORM.
