### PR TITLE
Allow media files to propagate through dpd middleware

### DIFF
--- a/demo/demo/templates/base.html
+++ b/demo/demo/templates/base.html
@@ -2,7 +2,7 @@
 <html>
  <head>
    {% load plotly_dash%}
-   {% load staticfiles%}
+   {% load static%}
    {% load bootstrap4%}
    {% bootstrap_css%}
    {% bootstrap_javascript jquery="full"%}

--- a/django_plotly_dash/middleware.py
+++ b/django_plotly_dash/middleware.py
@@ -133,12 +133,18 @@ class ExternalRedirectionMiddleware:
 
         response = self.get_response(request)
 
-        content = response.content
+        try:
+            content = response.content
 
-        for source, target in self.substitutions:
-            content = content.replace(source, target)
+            for source, target in self.substitutions:
+                content = content.replace(source, target)
 
-        response.content = content
+            response.content = content
+
+        except AttributeError:
+            # Not all files can contain substitutions, so ignore them
+            pass
+
         return response
 
     def _encode(self, string):

--- a/django_plotly_dash/templates/django_plotly_dash/plotly_messaging.html
+++ b/django_plotly_dash/templates/django_plotly_dash/plotly_messaging.html
@@ -1,4 +1,4 @@
-{%load staticfiles%}
+{%load static%}
 <script src="{%static "channels/js/websocketbridge.js"%}"></script>
 <script>
   if( !window.dpd_wsb ) {

--- a/django_plotly_dash/version.py
+++ b/django_plotly_dash/version.py
@@ -23,4 +23,4 @@ SOFTWARE.
 
 '''
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"


### PR DESCRIPTION
Stop dpd middleware from raising exceptions on files with streaming content
Bump version to 1.1.3
Change load tag from staticfiles to static

