### PR TITLE
Extend bootstrap example to show switch and checkbox variants

### DIFF
--- a/demo/demo/bootstrap_app.py
+++ b/demo/demo/bootstrap_app.py
@@ -29,12 +29,15 @@ import dash_html_components as html
 from django_plotly_dash import DjangoDash
 
 dd = DjangoDash("BootstrapApplication",
+                serve_locally=True,
                 add_bootstrap_links=True)
 
 dd.layout = html.Div(
     [
         dbc.Alert("This is an alert", color="primary"),
         dbc.Alert("Danger", color="danger"),
+        dbc.Checklist(id='check_switch', switch=True, options=[{"label": "An example switch", "value": 1}], value=[0]),
+        dbc.Checklist(id='check_check', switch=False, options=[{"label": "An example checkbox", "value": 1}], value=[0]),
         ]
     )
 

--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -140,7 +140,7 @@ PLOTLY_DASH = {
 
     "cache_arguments" : True, # True for cache, False for session-based argument propagation
 
-    #"serve_locally" : True, # True to serve assets locally, False to use their unadulterated urls (eg a CDN)
+    "serve_locally" : True, # True to serve assets locally, False to use their unadulterated urls (eg a CDN)
 
     "stateless_loader" : "demo.scaffold.stateless_app_loader",
     }

--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -140,7 +140,7 @@ PLOTLY_DASH = {
 
     "cache_arguments" : True, # True for cache, False for session-based argument propagation
 
-    "serve_locally" : True, # True to serve assets locally, False to use their unadulterated urls (eg a CDN)
+    #"serve_locally" : True, # True to serve assets locally, False to use their unadulterated urls (eg a CDN)
 
     "stateless_loader" : "demo.scaffold.stateless_app_loader",
     }

--- a/django_plotly_dash/version.py
+++ b/django_plotly_dash/version.py
@@ -23,4 +23,4 @@ SOFTWARE.
 
 '''
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"


### PR DESCRIPTION
Extend the bootstrap example to include checkboxes that are sensitive to the version of bootstrap used.
Version 4.3.1 of bootstrap (or higher) is needed for this to render correctly.
