### PR TITLE
Allow use of Django 3.0

### DIFF
--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -80,6 +80,8 @@ TEMPLATES = [
     },
 ]
 
+X_FRAME_OPTIONS = 'SAMEORIGIN'
+
 WSGI_APPLICATION = 'demo.wsgi.application'
 
 ASGI_APPLICATION = 'demo.routing.application'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ dpd-components
 
 dash-bootstrap-components
 
-Django>=2,<3
+Django>=3
 Flask>=1.0.2

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
                         'dash-html-components',
                         'dash-renderer',
                         'dpd-components',
-                        'Django>=2,<3',
+                        'Django>=3',
                         'Flask>=1.0.2'],
     python_requires=">=3.6",
     )


### PR DESCRIPTION
Remove constraint requiring use of Django 3.0
Update the documentation for X_FRAME_OPTIONS to permit use of iframes

