### PR TITLE
Correct dash State in dash_wrapper.py

### DIFF
--- a/django_plotly_dash/dash_wrapper.py
+++ b/django_plotly_dash/dash_wrapper.py
@@ -626,7 +626,7 @@ class WrappedDash(Dash):
                         da.update_current_state(c['id'], c['property'], v)
 
         for component_registration in self.callback_map[target_id]['state']:
-            for c in state:
+            for c in states:
                 if c['property'] == component_registration['property'] and c['id'] == component_registration['id']:
                     v = c.get('value', None)
                     args.append(v)


### PR DESCRIPTION
There was a missing 's' in line 629, wich leads to an error if you try to use dash States
"for c in state:" --> "for c in state:"