### PR TITLE
Update requirements to avoid use of later channels

### DIFF
--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -37,3 +37,5 @@ Thanks to the following people:
 [gurcke](https://github.com/gurcke)
 
 [CaseGuide](https://github.com/CaseGuide)
+
+[manish-podugu](https://github.com/manish-podugu)

--- a/django_plotly_dash/version.py
+++ b/django_plotly_dash/version.py
@@ -23,4 +23,4 @@ SOFTWARE.
 
 '''
 
-__version__ = "1.4.2"
+__version__ = "1.5.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ dpd-components
 
 dash-bootstrap-components
 
+channels<3.0
 Django>=2.2
 Flask>=1.0.2


### PR DESCRIPTION
Partly addresses #291 by suppressing the use of later channels versions
 