### PR TITLE
fix bug when a callback has a single output but in the list format

### DIFF
--- a/check_code_dpd
+++ b/check_code_dpd
@@ -2,4 +2,4 @@
 #
 source env/bin/activate
 #
-pylint django_plotly_dash
+pylint django_plotly_dash --rcfile=pylintrc

--- a/demo/demo/dash_apps.py
+++ b/demo/demo/dash_apps.py
@@ -133,3 +133,5 @@ def callback_test(*args, **kwargs): #pylint: disable=unused-argument
     children = [line_graph]
 
     return [children]
+
+

--- a/demo/demo/dash_apps.py
+++ b/demo/demo/dash_apps.py
@@ -50,9 +50,10 @@ dash_example1.layout = html.Div(id='main',
                                         className='col-md-12',
                                     ),
 
-                                    html.Div(id='test-output-div2')
+                                    html.Div(id='test-output-div2'),
+                                    html.Div(id='test-output-div3')
 
-                                    ]) # end of 'main'
+                                ]) # end of 'main'
 
 @dash_example1.expanded_callback(
     dash.dependencies.Output('test-output-div', 'children'),
@@ -100,3 +101,35 @@ def callback_test2(*args, **kwargs):
                 html.Div(["The session context message is '%s'" %(kwargs['session_state']['django_to_dash_context'])])]
 
     return children
+
+@dash_example1.expanded_callback(
+    [dash.dependencies.Output('test-output-div3', 'children')],
+    [dash.dependencies.Input('my-dropdown1', 'value')])
+def callback_test(*args, **kwargs): #pylint: disable=unused-argument
+    'Callback to generate test data on each change of the dropdown'
+
+    # Creating a random Graph from a Plotly example:
+    N = 500
+    random_x = np.linspace(0, 1, N)
+    random_y = np.random.randn(N)
+
+    # Create a trace
+    trace = go.Scatter(x=random_x,
+                       y=random_y)
+
+    data = [trace]
+
+    layout = dict(title='',
+                  yaxis=dict(zeroline=False, title='Total Expense (£)',),
+                  xaxis=dict(zeroline=False, title='Date', tickangle=0),
+                  margin=dict(t=20, b=50, l=50, r=40),
+                  height=350,
+                 )
+
+
+    fig = dict(data=data, layout=layout)
+    line_graph = dcc.Graph(id='line-area-graph2', figure=fig, style={'display':'inline-block', 'width':'100%',
+                                                                     'height':'100%;'})
+    children = [line_graph]
+
+    return [children]

--- a/demo/demo/plotly_apps.py
+++ b/demo/demo/plotly_apps.py
@@ -377,3 +377,37 @@ def multiple_callbacks_two(button_clicks, color_choice, **kwargs):
             "Output 2: %s %s %s" % (button_clicks, color_choice, kwargs['callback_context'].triggered),
             "Output 3: %s %s [%s]" % (button_clicks, color_choice, kwargs)
             ]
+
+
+flexible_expanded_callbacks = DjangoDash("FlexibleExpandedCallbacks")
+
+flexible_expanded_callbacks.layout = html.Div([
+    html.Button("Press Me",
+                id="button"),
+    dcc.RadioItems(id='dropdown-color',
+                   options=[{'label': c, 'value': c.lower()} for c in ['Red', 'Green', 'Blue']],
+                   value='red'
+                   ),
+    html.Div(id="output-one"),
+    html.Div(id="output-two"),
+    html.Div(id="output-three")
+    ])
+
+@flexible_expanded_callbacks.expanded_callback(
+    dash.dependencies.Output('output-one', 'children'),
+    [dash.dependencies.Input('button', 'n_clicks')])
+def exp_callback_kwargs(button_clicks, **kwargs):
+    return str(kwargs)
+
+
+@flexible_expanded_callbacks.expanded_callback(
+    dash.dependencies.Output('output-two', 'children'),
+    [dash.dependencies.Input('button', 'n_clicks')])
+def exp_callback_kwargs(button_clicks):
+    return "ok"
+
+@flexible_expanded_callbacks.expanded_callback(
+    dash.dependencies.Output('output-three', 'children'),
+    [dash.dependencies.Input('button', 'n_clicks')])
+def exp_callback_kwargs(button_clicks, dash_app_id):
+    return dash_app_id

--- a/demo/demo/scaffold.py
+++ b/demo/demo/scaffold.py
@@ -3,7 +3,7 @@
 from django_plotly_dash import DjangoDash
 from django.utils.module_loading import import_string
 
-from demo.plotly_apps import multiple_callbacks
+from demo.plotly_apps import multiple_callbacks, flexible_expanded_callbacks
 
 def stateless_app_loader(app_name):
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,6 +4,7 @@ coveralls>=1.6.0
 channels>=2.0
 channels-redis
 daphne
+dash-bootstrap-components
 Django>=2.0
 django-bootstrap4
 django-redis

--- a/django_plotly_dash/dash_wrapper.py
+++ b/django_plotly_dash/dash_wrapper.py
@@ -595,9 +595,6 @@ class WrappedDash(Dash):
                 # Multiple outputs
                 outputs = output[2:-2].split('...')
                 target_id = output
-                # Special case of a single output
-                if len(outputs) == 1:
-                    target_id = output[2:-2]
         except:
             pass
 

--- a/django_plotly_dash/tests.py
+++ b/django_plotly_dash/tests.py
@@ -202,6 +202,58 @@ def test_injection_updating_multiple_callbacks(client):
 
 
 @pytest.mark.django_db
+def test_flexible_expanded_callbacks(client):
+    'Check updating of an app using demo test data for flexible expanded callbacks'
+
+    from django.urls import reverse
+
+    route_name = 'update-component'
+
+    for prefix, arg_map in [('app-', {'ident':'flexible_expanded_callbacks'}),]:
+        url = reverse('the_django_plotly_dash:%s%s' % (prefix, route_name), kwargs=arg_map)
+
+        # output contains all arguments of the expanded_callback
+        response = client.post(url, json.dumps({'output':'output-one.children',
+                                                'inputs':[
+            {'id':'button',
+             'property':'n_clicks',
+             'value':'10'},
+                                                         ]}), content_type="application/json")
+
+        assert response.status_code == 200
+
+        resp = json.loads(response.content.decode('utf-8'))
+        for key in ["dash_app_id", "dash_app", "callback_context"]:
+            assert key in resp["response"]['output-one']['children']
+
+        # output contains all arguments of the expanded_callback
+        response = client.post(url, json.dumps({'output':'output-two.children',
+                                                'inputs':[
+            {'id':'button',
+             'property':'n_clicks',
+             'value':'10'},
+                                                         ]}), content_type="application/json")
+
+        assert response.status_code == 200
+
+        resp = json.loads(response.content.decode('utf-8'))
+        assert resp["response"]=={'output-two': {'children': 'ok'}}
+
+
+        # output contains all arguments of the expanded_callback
+        response = client.post(url, json.dumps({'output':'output-three.children',
+                                                'inputs':[
+            {'id':'button',
+             'property':'n_clicks',
+             'value':'10'},
+                                                         ]}), content_type="application/json")
+
+        assert response.status_code == 200
+
+        resp = json.loads(response.content.decode('utf-8'))
+        assert resp["response"]=={"output-three": {"children": "flexible_expanded_callbacks"}}
+
+@pytest.mark.django_db
 def test_injection_updating(client):
     'Check updating of an app using demo test data'
 

--- a/docs/extended_callbacks.rst
+++ b/docs/extended_callbacks.rst
@@ -5,9 +5,12 @@ Extended callback syntax
 
 The ``DjangoDash`` class allows callbacks to request extra arguments when registered.
 
-To do this, simply replace ``callback`` with ``expanded_callback`` when registering any callback. This will cause **all** of the callbacks
-registered with this application
-to receive extra ``kwargs`` in addition to the callback parameters.
+To do this, simply replace ``callback`` with ``expanded_callback`` when registering any callback. This will cause these expanded callbacks
+registered with this application to receive extra parameters in addition to the callback parameters.
+
+If you specify a ``kwargs`` in your callback, it will receive all possible extra parameters (see below for a list).
+If you specify, after the usual parameters for your ``Input`` and ``State``,
+some extra parameters from the list below, only these will be passed to your callback.
 
 For example, the ``plotly_apps.py`` example contains this dash application:
 
@@ -32,10 +35,9 @@ For example, the ``plotly_apps.py`` example contains this dash application:
       dash.dependencies.Output('output-one','children'),
       [dash.dependencies.Input('dropdown-one','value')]
       )
-
   def callback_c(*args,**kwargs):
       da = kwargs['dash_app']
-      return "Args are [%s] and kwargs are %s" %(",".join(args),str(kwargs))
+      return "Args are [%s] and kwargs are %s" %(",".join(args), kwargs)
 
 The additional arguments, which are reported as the ``kwargs`` content in this example, include
 
@@ -49,6 +51,25 @@ The additional arguments, which are reported as the ``kwargs`` content in this e
 :session_state: A dictionary of information, unique to this user session. Any changes made to its content during the
                 callback are persisted as part of the Django session framework.
 :user: The Django User instance.
+
+Possible alternatives to ``kwargs``
+
+.. code-block:: python
+
+  @a2.expanded_callback(
+      dash.dependencies.Output('output-one','children'),
+      [dash.dependencies.Input('dropdown-one','value')]
+      )
+  def callback_c(*args, dash_app):
+      return "Args are [%s] and the extra parameter dash_app is %s" %(",".join(args), dash_app)
+
+  @a2.expanded_callback(
+      dash.dependencies.Output('output-one','children'),
+      [dash.dependencies.Input('dropdown-one','value')]
+      )
+  def callback_c(*args, dash_app, **kwargs):
+      return "Args are [%s], the extra parameter dash_app is %s and kwargs are %s" %(",".join(args), dash_app, kwargs)
+
 
 The ``DashApp`` model instance can also be configured to persist itself on any change. This is discussed
 in the :ref:`models_and_state` section.


### PR DESCRIPTION
a key error was thrown as the target_id of the callback was in the format output_id.output_comp instead of ..output_id.output_comp.. that is required when the outputs of a callback are in a list