### PR TITLE
Flexible expanded callback

### DIFF
--- a/check_code_dpd
+++ b/check_code_dpd
@@ -2,4 +2,4 @@
 #
 source env/bin/activate
 #
-pylint django_plotly_dash
+pylint django_plotly_dash --rcfile=pylintrc

--- a/demo/demo/dash_apps.py
+++ b/demo/demo/dash_apps.py
@@ -133,3 +133,5 @@ def callback_test(*args, **kwargs): #pylint: disable=unused-argument
     children = [line_graph]
 
     return [children]
+
+

--- a/demo/demo/dash_apps.py
+++ b/demo/demo/dash_apps.py
@@ -94,9 +94,6 @@ def callback_test(*args, **kwargs): #pylint: disable=unused-argument
 def callback_test2(*args, **kwargs):
     'Callback to exercise session functionality'
 
-    print(args)
-    print(kwargs)
-
     children = [html.Div(["You have selected %s." %(args[0])]),
                 html.Div(["The session context message is '%s'" %(kwargs['session_state']['django_to_dash_context'])])]
 

--- a/demo/demo/dash_apps.py
+++ b/demo/demo/dash_apps.py
@@ -50,9 +50,10 @@ dash_example1.layout = html.Div(id='main',
                                         className='col-md-12',
                                     ),
 
-                                    html.Div(id='test-output-div2')
+                                    html.Div(id='test-output-div2'),
+                                    html.Div(id='test-output-div3')
 
-                                    ]) # end of 'main'
+                                ]) # end of 'main'
 
 @dash_example1.expanded_callback(
     dash.dependencies.Output('test-output-div', 'children'),
@@ -100,3 +101,35 @@ def callback_test2(*args, **kwargs):
                 html.Div(["The session context message is '%s'" %(kwargs['session_state']['django_to_dash_context'])])]
 
     return children
+
+@dash_example1.expanded_callback(
+    [dash.dependencies.Output('test-output-div3', 'children')],
+    [dash.dependencies.Input('my-dropdown1', 'value')])
+def callback_test(*args, **kwargs): #pylint: disable=unused-argument
+    'Callback to generate test data on each change of the dropdown'
+
+    # Creating a random Graph from a Plotly example:
+    N = 500
+    random_x = np.linspace(0, 1, N)
+    random_y = np.random.randn(N)
+
+    # Create a trace
+    trace = go.Scatter(x=random_x,
+                       y=random_y)
+
+    data = [trace]
+
+    layout = dict(title='',
+                  yaxis=dict(zeroline=False, title='Total Expense (£)',),
+                  xaxis=dict(zeroline=False, title='Date', tickangle=0),
+                  margin=dict(t=20, b=50, l=50, r=40),
+                  height=350,
+                 )
+
+
+    fig = dict(data=data, layout=layout)
+    line_graph = dcc.Graph(id='line-area-graph2', figure=fig, style={'display':'inline-block', 'width':'100%',
+                                                                     'height':'100%;'})
+    children = [line_graph]
+
+    return [children]

--- a/demo/demo/plotly_apps.py
+++ b/demo/demo/plotly_apps.py
@@ -403,11 +403,11 @@ def exp_callback_kwargs(button_clicks, **kwargs):
 @flexible_expanded_callbacks.expanded_callback(
     dash.dependencies.Output('output-two', 'children'),
     [dash.dependencies.Input('button', 'n_clicks')])
-def exp_callback_kwargs(button_clicks):
+def exp_callback_standard(button_clicks):
     return "ok"
 
 @flexible_expanded_callbacks.expanded_callback(
     dash.dependencies.Output('output-three', 'children'),
     [dash.dependencies.Input('button', 'n_clicks')])
-def exp_callback_kwargs(button_clicks, dash_app_id):
+def exp_callback_dash_app_id(button_clicks, dash_app_id):
     return dash_app_id

--- a/demo/demo/plotly_apps.py
+++ b/demo/demo/plotly_apps.py
@@ -377,3 +377,37 @@ def multiple_callbacks_two(button_clicks, color_choice, **kwargs):
             "Output 2: %s %s %s" % (button_clicks, color_choice, kwargs['callback_context'].triggered),
             "Output 3: %s %s [%s]" % (button_clicks, color_choice, kwargs)
             ]
+
+
+flexible_expanded_callbacks = DjangoDash("FlexibleExpandedCallbacks")
+
+flexible_expanded_callbacks.layout = html.Div([
+    html.Button("Press Me",
+                id="button"),
+    dcc.RadioItems(id='dropdown-color',
+                   options=[{'label': c, 'value': c.lower()} for c in ['Red', 'Green', 'Blue']],
+                   value='red'
+                   ),
+    html.Div(id="output-one"),
+    html.Div(id="output-two"),
+    html.Div(id="output-three")
+    ])
+
+@flexible_expanded_callbacks.expanded_callback(
+    dash.dependencies.Output('output-one', 'children'),
+    [dash.dependencies.Input('button', 'n_clicks')])
+def exp_callback_kwargs(button_clicks, **kwargs):
+    return str(kwargs)
+
+
+@flexible_expanded_callbacks.expanded_callback(
+    dash.dependencies.Output('output-two', 'children'),
+    [dash.dependencies.Input('button', 'n_clicks')])
+def exp_callback_kwargs(button_clicks):
+    return "ok"
+
+@flexible_expanded_callbacks.expanded_callback(
+    dash.dependencies.Output('output-three', 'children'),
+    [dash.dependencies.Input('button', 'n_clicks')])
+def exp_callback_kwargs(button_clicks, dash_app_id):
+    return dash_app_id

--- a/demo/demo/scaffold.py
+++ b/demo/demo/scaffold.py
@@ -3,7 +3,7 @@
 from django_plotly_dash import DjangoDash
 from django.utils.module_loading import import_string
 
-from demo.plotly_apps import multiple_callbacks
+from demo.plotly_apps import multiple_callbacks, flexible_expanded_callbacks
 
 def stateless_app_loader(app_name):
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,6 +4,7 @@ coveralls>=1.6.0
 channels>=2.0
 channels-redis
 daphne
+dash-bootstrap-components
 Django>=2.0
 django-bootstrap4
 django-redis

--- a/django_plotly_dash/dash_wrapper.py
+++ b/django_plotly_dash/dash_wrapper.py
@@ -293,10 +293,10 @@ class DjangoDash:
         If add_expanded_arguments is True, it will inspect the signature of the function to
         ensure only relevant expanded argument are passed to the callback.
         '''
-        callback_set = {'output':output,
-                        'inputs':inputs and inputs or dict(),
-                        'state':state and state or dict(),
-                        'events':events and events or dict()}
+        callback_set = {'output': output,
+                        'inputs': inputs or dict(),
+                        'state': state or dict(),
+                        'events': events or dict()}
 
         def wrap_func(func, callback_set=callback_set, callback_sets=self._callback_sets): # pylint: disable=dangerous-default-value, missing-docstring
             callback_sets.append((callback_set, func))

--- a/django_plotly_dash/dash_wrapper.py
+++ b/django_plotly_dash/dash_wrapper.py
@@ -24,7 +24,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 '''
-
+import itertools
 import json
 import inspect
 
@@ -160,7 +160,6 @@ class DjangoDash:
     '''
     #pylint: disable=too-many-instance-attributes
     def __init__(self, name=None, serve_locally=None,
-                 expanded_callbacks=False,
                  add_bootstrap_links=False,
                  suppress_callback_exceptions=False,
                  **kwargs): # pylint: disable=unused-argument, too-many-arguments
@@ -186,7 +185,6 @@ class DjangoDash:
         else:
             self._serve_locally = serve_locally
 
-        self._expanded_callbacks = expanded_callbacks
         self._suppress_callback_exceptions = suppress_callback_exceptions
 
         if add_bootstrap_links:
@@ -268,7 +266,6 @@ class DjangoDash:
             ndid = self._uid
 
         rd = WrappedDash(base_pathname=base_pathname,
-                         expanded_callbacks=self._expanded_callbacks,
                          replacements=replacements,
                          ndid=ndid,
                          serve_locally=self._serve_locally)
@@ -287,16 +284,48 @@ class DjangoDash:
 
         return rd
 
-    def callback(self, output, inputs=None, state=None, events=None, add_expanded_arguments=False):
-        '''Form a callback function by wrapping, in the same way as the underlying Dash application would
+    @staticmethod
+    def get_expanded_arguments(func, inputs, state):
+        """Analyse a callback function signature to detect the expanded arguments to add when called.
+        It uses the inputs and the state information to identify what arguments are already coming from Dash.
 
-        If add_expanded_arguments is True, it will inspect the signature of the function to
-        ensure only relevant expanded argument are passed to the callback.
+        It returns a list of the expanded parameters to inject (can be [] if nothing should be injected)
+         or None if all parameters should be injected."""
+        n_dash_parameters = len(inputs or []) + len(state or [])
+
+        parameter_types = {kind: [p.name for p in parameters] for kind, parameters in
+                           itertools.groupby(inspect.signature(func).parameters.values(), lambda p: p.kind)}
+        if inspect.Parameter.VAR_KEYWORD in parameter_types:
+            # there is some **kwargs, inject all parameters
+            expanded = None
+        elif inspect.Parameter.VAR_POSITIONAL in parameter_types:
+            # there is a *args, assume all parameters afterwards (KEYWORD_ONLY) are to be injected
+            # some of these parameters may not be expanded arguments but that is ok
+            expanded = parameter_types.get(inspect.Parameter.KEYWORD_ONLY, [])
+        else:
+            # there is no **kwargs, filter argMap to take only the keyword arguments
+            expanded = parameter_types.get(inspect.Parameter.POSITIONAL_OR_KEYWORD, [])[
+                       n_dash_parameters:] + parameter_types.get(inspect.Parameter.KEYWORD_ONLY, [])
+
+        print(func, parameter_types, "->",expanded)
+
+        return expanded
+
+    def callback(self, output, inputs=None, state=None, events=None):
+        '''Form a callback function by wrapping, in the same way as the underlying Dash application would
+        but handling extra arguments provided by dpd.
+
+        It will inspect the signature of the function to ensure only relevant expanded arguments are passed to the callback.
+
+        If the function accepts a **kwargs => all expanded arguments are sent to the function in the kwargs.
+        If the function has a *args => expanded arguments matching parameters after the *args are injected.
+        Otherwise, take all arguments beyond the one provided by Dash (based on the Inputs/States provided).
+
         '''
         callback_set = {'output': output,
-                        'inputs': inputs or dict(),
-                        'state': state or dict(),
-                        'events': events or dict()}
+                        'inputs': inputs or [],
+                        'state': state or [],
+                        'events': events or []}
 
         def wrap_func(func):
             self._callback_sets.append((callback_set, func))
@@ -304,31 +333,11 @@ class DjangoDash:
             # to inject properly only the expanded arguments the function can accept
             # if .expanded is None => inject all
             # if .expanded is a list => inject only
-            if add_expanded_arguments:
-                parameters = inspect.signature(func).parameters
-
-                if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in parameters.values()):
-                    # there is some **kwargs, do not filter argMap later
-                    func.expanded = None
-                else:
-                    # there is no **kwargs, filter argMap to take only the keyword arguments
-                    KEYWORD_TYPES = {inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY}
-                    func.expanded = [k for k, p in parameters.items() if p.kind in KEYWORD_TYPES] + ["outputs_list"]
-            else:
-                # send only the outputs_list as it is not an expanded_callback
-                func.expanded = ["outputs_list"]
+            func.expanded = DjangoDash.get_expanded_arguments(func, inputs, state)
             return func
         return wrap_func
 
-    def expanded_callback(self, output, inputs=[], state=[], events=[]): # pylint: disable=dangerous-default-value
-        '''
-        Form an expanded callback.
-
-        This function registers the callback function, and sets an internal flag that mandates that all
-        callbacks are passed the enhanced arguments.
-        '''
-        self._expanded_callbacks = True
-        return self.callback(output, inputs, state, events, add_expanded_arguments=True)
+    expanded_callback = callback
 
     def clientside_callback(self, clientside_function, output, inputs=None, state=None):
         'Form a callback function by wrapping, in the same way as the underlying Dash application would'
@@ -380,8 +389,7 @@ class WrappedDash(Dash):
     'Wrapper around the Plotly Dash application instance'
     # pylint: disable=too-many-arguments, too-many-instance-attributes
     def __init__(self,
-                 base_pathname=None, replacements=None, ndid=None,
-                 expanded_callbacks=False, serve_locally=False,
+                 base_pathname=None, replacements=None, ndid=None, serve_locally=False,
                  **kwargs):
 
         self._uid = ndid
@@ -400,7 +408,6 @@ class WrappedDash(Dash):
         self.scripts.config.serve_locally = serve_locally
 
         self._adjust_id = False
-        self._dash_dispatch = not expanded_callbacks
         if replacements:
             self._replacements = replacements
         else:
@@ -408,10 +415,6 @@ class WrappedDash(Dash):
         self._use_dash_layout = len(self._replacements) < 1
 
         self._return_embedded = False
-
-    def use_dash_dispatch(self):
-        'Indicate if dispatch is using underlying dash code or the wrapped code'
-        return self._dash_dispatch
 
     def use_dash_layout(self):
         '''
@@ -667,8 +670,9 @@ class WrappedDash(Dash):
 
         callback = callback_info["callback"]
         # smart injection of parameters if .expanded is defined
-        if callback.expanded:
-            res = callback(*args, **{k:v for k,v in argMap.items() if k in callback.expanded})
+        if callback.expanded is not None:
+            parameters_to_inject = {*callback.expanded, 'outputs_list'}
+            res = callback(*args, **{k: v for k, v in argMap.items() if k in parameters_to_inject})
         else:
             res = callback(*args, **argMap)
         if da:

--- a/django_plotly_dash/dash_wrapper.py
+++ b/django_plotly_dash/dash_wrapper.py
@@ -307,8 +307,6 @@ class DjangoDash:
             expanded = parameter_types.get(inspect.Parameter.POSITIONAL_OR_KEYWORD, [])[
                        n_dash_parameters:] + parameter_types.get(inspect.Parameter.KEYWORD_ONLY, [])
 
-        print(func, parameter_types, "->",expanded)
-
         return expanded
 
     def callback(self, output, inputs=None, state=None, events=None):

--- a/django_plotly_dash/dash_wrapper.py
+++ b/django_plotly_dash/dash_wrapper.py
@@ -298,8 +298,8 @@ class DjangoDash:
                         'state': state or dict(),
                         'events': events or dict()}
 
-        def wrap_func(func, callback_set=callback_set, callback_sets=self._callback_sets): # pylint: disable=dangerous-default-value, missing-docstring
-            callback_sets.append((callback_set, func))
+        def wrap_func(func):
+            self._callback_sets.append((callback_set, func))
             # add an expanded attribute to the function with the information to use in dispatch_with_args
             # to inject properly only the expanded arguments the function can accept
             # if .expanded is None => inject all

--- a/django_plotly_dash/dash_wrapper.py
+++ b/django_plotly_dash/dash_wrapper.py
@@ -595,9 +595,6 @@ class WrappedDash(Dash):
                 # Multiple outputs
                 outputs = output[2:-2].split('...')
                 target_id = output
-                # Special case of a single output
-                if len(outputs) == 1:
-                    target_id = output[2:-2]
         except:
             pass
 

--- a/django_plotly_dash/tests.py
+++ b/django_plotly_dash/tests.py
@@ -202,6 +202,58 @@ def test_injection_updating_multiple_callbacks(client):
 
 
 @pytest.mark.django_db
+def test_flexible_expanded_callbacks(client):
+    'Check updating of an app using demo test data for flexible expanded callbacks'
+
+    from django.urls import reverse
+
+    route_name = 'update-component'
+
+    for prefix, arg_map in [('app-', {'ident':'flexible_expanded_callbacks'}),]:
+        url = reverse('the_django_plotly_dash:%s%s' % (prefix, route_name), kwargs=arg_map)
+
+        # output contains all arguments of the expanded_callback
+        response = client.post(url, json.dumps({'output':'output-one.children',
+                                                'inputs':[
+            {'id':'button',
+             'property':'n_clicks',
+             'value':'10'},
+                                                         ]}), content_type="application/json")
+
+        assert response.status_code == 200
+
+        resp = json.loads(response.content.decode('utf-8'))
+        for key in ["dash_app_id", "dash_app", "callback_context"]:
+            assert key in resp["response"]['output-one']['children']
+
+        # output contains all arguments of the expanded_callback
+        response = client.post(url, json.dumps({'output':'output-two.children',
+                                                'inputs':[
+            {'id':'button',
+             'property':'n_clicks',
+             'value':'10'},
+                                                         ]}), content_type="application/json")
+
+        assert response.status_code == 200
+
+        resp = json.loads(response.content.decode('utf-8'))
+        assert resp["response"]=={'output-two': {'children': 'ok'}}
+
+
+        # output contains all arguments of the expanded_callback
+        response = client.post(url, json.dumps({'output':'output-three.children',
+                                                'inputs':[
+            {'id':'button',
+             'property':'n_clicks',
+             'value':'10'},
+                                                         ]}), content_type="application/json")
+
+        assert response.status_code == 200
+
+        resp = json.loads(response.content.decode('utf-8'))
+        assert resp["response"]=={"output-three": {"children": "flexible_expanded_callbacks"}}
+
+@pytest.mark.django_db
 def test_injection_updating(client):
     'Check updating of an app using demo test data'
 

--- a/django_plotly_dash/tests.py
+++ b/django_plotly_dash/tests.py
@@ -31,6 +31,9 @@ import pytest
 import json
 
 #pylint: disable=bare-except
+from dash.dependencies import Input
+
+from django_plotly_dash import DjangoDash
 
 
 def test_dash_app():
@@ -444,3 +447,46 @@ def test_app_loading(client):
     assert response.status_code == 302
 
 
+def test_callback_decorator():
+    inputs = [Input("one", "value"),
+              Input("two", "value"),
+              ]
+    states = [Input("three", "value"),
+              Input("four", "value"),
+              ]
+
+    def callback_standard(one, two, three, four):
+        return
+
+    assert DjangoDash.get_expanded_arguments(callback_standard, inputs, states) == []
+
+    def callback_standard(one, two, three, four, extra_1):
+        return
+
+    assert DjangoDash.get_expanded_arguments(callback_standard, inputs, states) == ['extra_1']
+
+    def callback_args(one, *args):
+        return
+
+    assert DjangoDash.get_expanded_arguments(callback_args, inputs, states) == []
+
+    def callback_args_extra(one, *args, extra_1):
+        return
+
+    assert DjangoDash.get_expanded_arguments(callback_args_extra, inputs, states) == ['extra_1' ]
+
+    def callback_args_extra_star(one, *, extra_1):
+        return
+
+    assert DjangoDash.get_expanded_arguments(callback_args_extra_star, inputs, states) == ['extra_1' ]
+
+
+    def callback_kwargs(one, two, three, four, extra_1, **kwargs):
+        return
+
+    assert DjangoDash.get_expanded_arguments(callback_kwargs, inputs, states) == None
+
+    def callback_kwargs(one, two, three, four, *, extra_1, **kwargs, ):
+        return
+
+    assert DjangoDash.get_expanded_arguments(callback_kwargs, inputs, states) == None

--- a/django_plotly_dash/views.py
+++ b/django_plotly_dash/views.py
@@ -81,27 +81,16 @@ def _update(request, ident, stateless=False, **kwargs):
 
     request_body = json.loads(request.body.decode('utf-8'))
 
-    if app.use_dash_dispatch():
-        # Force call through dash
-        view_func = app.locate_endpoint_function('dash-update-component')
-
-        import flask
-        with app.test_request_context():
-            # Fudge request object
-            # pylint: disable=protected-access
-            flask.request._cached_json = (request_body, flask.request._cached_json[True])
-            resp = view_func()
-    else:
-        # Use direct dispatch with extra arguments in the argMap
-        app_state = request.session.get("django_plotly_dash", dict())
-        arg_map = {'dash_app_id': ident,
-                   'dash_app': dash_app,
-                   'user': request.user,
-                   'request':request,
-                   'session_state': app_state}
-        resp = app.dispatch_with_args(request_body, arg_map)
-        request.session['django_plotly_dash'] = app_state
-        dash_app.handle_current_state()
+    # Use direct dispatch with extra arguments in the argMap
+    app_state = request.session.get("django_plotly_dash", dict())
+    arg_map = {'dash_app_id': ident,
+               'dash_app': dash_app,
+               'user': request.user,
+               'request':request,
+               'session_state': app_state}
+    resp = app.dispatch_with_args(request_body, arg_map)
+    request.session['django_plotly_dash'] = app_state
+    dash_app.handle_current_state()
 
     # Special for ws-driven edge case
     if str(resp) == 'EDGECASEEXIT':

--- a/docs/demo_notes.rst
+++ b/docs/demo_notes.rst
@@ -87,10 +87,10 @@ are used to form the layout::
         ]
     )
 
-Within the :ref:`expanded callback <extended_callbacks>`, the session state is passed as an extra
+Within the :ref:`extended callback <extended_callbacks>`, the session state is passed as an extra
 argument compared to the standard ``Dash`` callback::
 
-    @dis.expanded_callback(
+    @dis.callback(
         dash.dependencies.Output("danger-alert", 'children'),
         [dash.dependencies.Input('update-button', 'n_clicks'),]
         )

--- a/docs/extended_callbacks.rst
+++ b/docs/extended_callbacks.rst
@@ -5,9 +5,12 @@ Extended callback syntax
 
 The ``DjangoDash`` class allows callbacks to request extra arguments when registered.
 
-To do this, simply replace ``callback`` with ``expanded_callback`` when registering any callback. This will cause **all** of the callbacks
-registered with this application
-to receive extra ``kwargs`` in addition to the callback parameters.
+To do this, simply replace ``callback`` with ``expanded_callback`` when registering any callback. This will cause these expanded callbacks
+registered with this application to receive extra parameters in addition to the callback parameters.
+
+If you specify a ``kwargs`` in your callback, it will receive all possible extra parameters (see below for a list).
+If you specify, after the usual parameters for your ``Input`` and ``State``,
+some extra parameters from the list below, only these will be passed to your callback.
 
 For example, the ``plotly_apps.py`` example contains this dash application:
 
@@ -32,10 +35,9 @@ For example, the ``plotly_apps.py`` example contains this dash application:
       dash.dependencies.Output('output-one','children'),
       [dash.dependencies.Input('dropdown-one','value')]
       )
-
   def callback_c(*args,**kwargs):
       da = kwargs['dash_app']
-      return "Args are [%s] and kwargs are %s" %(",".join(args),str(kwargs))
+      return "Args are [%s] and kwargs are %s" %(",".join(args), kwargs)
 
 The additional arguments, which are reported as the ``kwargs`` content in this example, include
 
@@ -49,6 +51,25 @@ The additional arguments, which are reported as the ``kwargs`` content in this e
 :session_state: A dictionary of information, unique to this user session. Any changes made to its content during the
                 callback are persisted as part of the Django session framework.
 :user: The Django User instance.
+
+Possible alternatives to ``kwargs``
+
+.. code-block:: python
+
+  @a2.expanded_callback(
+      dash.dependencies.Output('output-one','children'),
+      [dash.dependencies.Input('dropdown-one','value')]
+      )
+  def callback_c(*args, dash_app):
+      return "Args are [%s] and the extra parameter dash_app is %s" %(",".join(args), dash_app)
+
+  @a2.expanded_callback(
+      dash.dependencies.Output('output-one','children'),
+      [dash.dependencies.Input('dropdown-one','value')]
+      )
+  def callback_c(*args, dash_app, **kwargs):
+      return "Args are [%s], the extra parameter dash_app is %s and kwargs are %s" %(",".join(args), dash_app, kwargs)
+
 
 The ``DashApp`` model instance can also be configured to persist itself on any change. This is discussed
 in the :ref:`models_and_state` section.

--- a/docs/extended_callbacks.rst
+++ b/docs/extended_callbacks.rst
@@ -5,12 +5,13 @@ Extended callback syntax
 
 The ``DjangoDash`` class allows callbacks to request extra arguments when registered.
 
-To do this, simply replace ``callback`` with ``expanded_callback`` when registering any callback. This will cause these expanded callbacks
-registered with this application to receive extra parameters in addition to the callback parameters.
+To do this, simply add to your callback function the extra arguments you would like to receive
+after the usual parameters for your ``Input`` and ``State``.
+This will cause these callbacks registered with this application to receive extra parameters
+in addition to their usual callback parameters.
 
 If you specify a ``kwargs`` in your callback, it will receive all possible extra parameters (see below for a list).
-If you specify, after the usual parameters for your ``Input`` and ``State``,
-some extra parameters from the list below, only these will be passed to your callback.
+If you specify explicitly extra parameters from the list below, only these will be passed to your callback.
 
 For example, the ``plotly_apps.py`` example contains this dash application:
 
@@ -31,7 +32,7 @@ For example, the ``plotly_apps.py`` example contains this dash application:
       html.Div(id="output-one")
       ])
 
-  @a2.expanded_callback(
+  @a2.callback(
       dash.dependencies.Output('output-one','children'),
       [dash.dependencies.Input('dropdown-one','value')]
       )
@@ -42,7 +43,7 @@ For example, the ``plotly_apps.py`` example contains this dash application:
 The additional arguments, which are reported as the ``kwargs`` content in this example, include
 
 :callback_context: The ``Dash`` callback context. See the `documentation <https://dash.plotly.com/advanced-callbacks`_ on the content of
-                   this variable. This variable is provided as an argument to the expanded callback as well as
+                   this variable. This variable is provided as an argument to the callback as well as
                    the ``dash.callback_context`` global variable.
 :dash_app: For stateful applications, the ``DashApp`` model instance
 :dash_app_id: The application identifier. For stateless applications, this is the (slugified) name given to the ``DjangoDash`` constructor.
@@ -56,14 +57,14 @@ Possible alternatives to ``kwargs``
 
 .. code-block:: python
 
-  @a2.expanded_callback(
+  @a2.callback(
       dash.dependencies.Output('output-one','children'),
       [dash.dependencies.Input('dropdown-one','value')]
       )
   def callback_c(*args, dash_app):
       return "Args are [%s] and the extra parameter dash_app is %s" %(",".join(args), dash_app)
 
-  @a2.expanded_callback(
+  @a2.callback(
       dash.dependencies.Output('output-one','children'),
       [dash.dependencies.Input('dropdown-one','value')]
       )


### PR DESCRIPTION
allow a more flexible use of expanded_callback:
- no obligation to adapt the signature of a callback (by adding a **kwargs) when going from app.callback to app.expanded_callback 
- allow to specify the name of the specific extra parameters needed by the function (no need for **kwargs) to improve readability like in

```python
# current version
@app.expanded_callback(...)
def my_callback(..., **kwargs): ...

# new flexible version : no need to add **kwargs if not needed
@app.expanded_callback(...)
def my_callback(...): ...

# new flexible version : just get two of the new parameters (user and callback_context
@app.expanded_callback(...)
def my_callback(..., user, callback_context): ...

# new flexible version : get two of the new parameters and the rest in **kwargs
@app.expanded_callback(...)
def my_callback(..., user, callback_context, **kwargs): ...

```
