### PR TITLE
parse JSON response to update DA state only if needed

### DIFF
--- a/django_plotly_dash/dash_wrapper.py
+++ b/django_plotly_dash/dash_wrapper.py
@@ -705,7 +705,17 @@ class WrappedDash(Dash):
             res = callback(*args, **argMap)
 
         if da:
-            root_value = json.loads(res).get('response', {})
+            class LazyJson:
+                def __init__(self, func):
+                    self._func = func
+                    self._root_value = None
+
+                def get(self, item, default):
+                    if self._root_value is None:
+                        self._root_value = self._func()
+                    return self._root_value.get(item, default)
+
+            root_value = LazyJson(lambda: json.loads(res).get('response', {}))
 
             for output_item in outputs:
                 if isinstance(output_item, str):

--- a/django_plotly_dash/dash_wrapper.py
+++ b/django_plotly_dash/dash_wrapper.py
@@ -28,6 +28,7 @@ import inspect
 import itertools
 import json
 import warnings
+from typing import Dict, List, Callable
 
 import dash
 from dash import Dash, dependencies
@@ -45,8 +46,6 @@ from .util import static_asset_path
 
 try:
     from dataclasses import dataclass
-    from typing import Dict, List, Callable
-
 
     @dataclass(frozen=True)
     class CallbackContext:

--- a/django_plotly_dash/tests.py
+++ b/django_plotly_dash/tests.py
@@ -79,33 +79,37 @@ def test_dash_stateful_app_client_contract(client):
 
     # set the initial expected state
     expected_state = {'inp1': {'n_clicks': 0, 'n_clicks_timestamp': 1611733453854},
-                      'inp2': {'n_clicks': 5, 'n_clicks_timestamp': 1611733454354},
+                      'inp1b': {'n_clicks': 5, 'n_clicks_timestamp': 1611733454354},
+                      'inp2': {'n_clicks': 7, 'n_clicks_timestamp': 1611733454554},
                       'out1-0': {'n_clicks': 1, 'n_clicks_timestamp': 1611733453954},
                       'out1-1': {'n_clicks': 2, 'n_clicks_timestamp': 1611733454054},
                       'out1-2': {'n_clicks': 3, 'n_clicks_timestamp': 1611733454154},
                       'out1-3': {'n_clicks': 4, 'n_clicks_timestamp': 1611733454254},
-                      'out2-0': {'n_clicks': 6, 'n_clicks_timestamp': 1611733454454},
-                      'out3': {'n_clicks': 10, 'n_clicks_timestamp': 1611733454854},
-                      'out4': {'n_clicks': 14, 'n_clicks_timestamp': 1611733455254},
-                      'out5': {'n_clicks': 18, 'n_clicks_timestamp': 1611733455654},
-                      '{"_id":"inp-0","_type":"btn3"}': {'n_clicks': 7,
-                                                         'n_clicks_timestamp': 1611733454554},
-                      '{"_id":"inp-0","_type":"btn4"}': {'n_clicks': 11,
-                                                         'n_clicks_timestamp': 1611733454954},
-                      '{"_id":"inp-0","_type":"btn5"}': {'n_clicks': 15,
-                                                         'n_clicks_timestamp': 1611733455354},
-                      '{"_id":"inp-1","_type":"btn3"}': {'n_clicks': 8,
-                                                         'n_clicks_timestamp': 1611733454654},
-                      '{"_id":"inp-1","_type":"btn4"}': {'n_clicks': 12,
-                                                         'n_clicks_timestamp': 1611733455054},
-                      '{"_id":"inp-1","_type":"btn5"}': {'n_clicks': 16,
-                                                         'n_clicks_timestamp': 1611733455454},
-                      '{"_id":"inp-2","_type":"btn3"}': {'n_clicks': 9,
+                      'out1b': {'href': 'http://www.example.com/null',
+                                'n_clicks': 6,
+                                'n_clicks_timestamp': 1611733454454},
+                      'out2-0': {'n_clicks': 8, 'n_clicks_timestamp': 1611733454654},
+                      'out3': {'n_clicks': 12, 'n_clicks_timestamp': 1611733455054},
+                      'out4': {'n_clicks': 16, 'n_clicks_timestamp': 1611733455454},
+                      'out5': {'n_clicks': 20, 'n_clicks_timestamp': 1611733455854},
+                      '{"_id":"inp-0","_type":"btn3"}': {'n_clicks': 9,
                                                          'n_clicks_timestamp': 1611733454754},
-                      '{"_id":"inp-2","_type":"btn4"}': {'n_clicks': 13,
+                      '{"_id":"inp-0","_type":"btn4"}': {'n_clicks': 13,
                                                          'n_clicks_timestamp': 1611733455154},
-                      '{"_id":"inp-2","_type":"btn5"}': {'n_clicks': 17,
-                                                         'n_clicks_timestamp': 1611733455554}}
+                      '{"_id":"inp-0","_type":"btn5"}': {'n_clicks': 17,
+                                                         'n_clicks_timestamp': 1611733455554},
+                      '{"_id":"inp-1","_type":"btn3"}': {'n_clicks': 10,
+                                                         'n_clicks_timestamp': 1611733454854},
+                      '{"_id":"inp-1","_type":"btn4"}': {'n_clicks': 14,
+                                                         'n_clicks_timestamp': 1611733455254},
+                      '{"_id":"inp-1","_type":"btn5"}': {'n_clicks': 18,
+                                                         'n_clicks_timestamp': 1611733455654},
+                      '{"_id":"inp-2","_type":"btn3"}': {'n_clicks': 11,
+                                                         'n_clicks_timestamp': 1611733454954},
+                      '{"_id":"inp-2","_type":"btn4"}': {'n_clicks': 15,
+                                                         'n_clicks_timestamp': 1611733455354},
+                      '{"_id":"inp-2","_type":"btn5"}': {'n_clicks': 19,
+                                                         'n_clicks_timestamp': 1611733455754}}
 
     ########## test state management of the app and conversion of components ids
     # search for state values in dash layout
@@ -122,7 +126,7 @@ def test_dash_stateful_app_client_contract(client):
 
     # update an existent state => update current_state
     stateful_a.update_current_state('{"_id":"inp-2","_type":"btn5"}', "n_clicks", 100)
-    expected_state['{"_id":"inp-2","_type":"btn5"}'] = {'n_clicks': 100, 'n_clicks_timestamp': 1611733455554}
+    expected_state['{"_id":"inp-2","_type":"btn5"}'] = {'n_clicks': 100, 'n_clicks_timestamp': 1611733455754}
     assert stateful_a.current_state() == expected_state
 
     assert DashApp.objects.get(instance_name="Some name").current_state() == {}
@@ -170,34 +174,38 @@ def test_dash_stateful_app_client_contract(client):
         stateful_a.handle_current_state()
 
     # check final state has been changed accordingly
-    final_state = {'inp1': {'n_clicks': 1, 'n_clicks_timestamp': 1611736145932},
-                   'inp2': {'n_clicks': 6, 'n_clicks_timestamp': 1611736146875},
+    final_state = {'inp1': {'n_clicks': 1, 'n_clicks_timestamp': 1615103027288},
+                   'inp1b': {'n_clicks': 5, 'n_clicks_timestamp': 1615103033482},
+                   'inp2': {'n_clicks': 8, 'n_clicks_timestamp': 1615103036591},
                    'out1-0': {'n_clicks': 1, 'n_clicks_timestamp': 1611733453954},
                    'out1-1': {'n_clicks': 2, 'n_clicks_timestamp': 1611733454054},
                    'out1-2': {'n_clicks': 3, 'n_clicks_timestamp': 1611733454154},
                    'out1-3': {'n_clicks': 4, 'n_clicks_timestamp': 1611733454254},
-                   'out2-0': {'n_clicks': 6, 'n_clicks_timestamp': 1611733454454},
-                   'out3': {'n_clicks': 10, 'n_clicks_timestamp': 1611733454854},
-                   'out4': {'n_clicks': 14, 'n_clicks_timestamp': 1611733455254},
-                   'out5': {'n_clicks': 18, 'n_clicks_timestamp': 1611733455654},
-                   '{"_id":"inp-0","_type":"btn3"}': {'n_clicks': 8,
-                                                      'n_clicks_timestamp': 1611736147644},
-                   '{"_id":"inp-0","_type":"btn4"}': {'n_clicks': 12,
-                                                      'n_clicks_timestamp': 1611733454954},
-                   '{"_id":"inp-0","_type":"btn5"}': {'n_clicks': 16,
-                                                      'n_clicks_timestamp': 1611733455354},
-                   '{"_id":"inp-1","_type":"btn3"}': {'n_clicks': 9,
-                                                      'n_clicks_timestamp': 1611736148172},
-                   '{"_id":"inp-1","_type":"btn4"}': {'n_clicks': 13,
-                                                      'n_clicks_timestamp': 1611733455054},
-                   '{"_id":"inp-1","_type":"btn5"}': {'n_clicks': 18,
-                                                      'n_clicks_timestamp': 1611733455454},
-                   '{"_id":"inp-2","_type":"btn3"}': {'n_clicks': 10,
-                                                      'n_clicks_timestamp': 1611736149140},
-                   '{"_id":"inp-2","_type":"btn4"}': {'n_clicks': 13,
+                   'out1b': {'href': 'http://www.example.com/1615103033482',
+                             'n_clicks': 6,
+                             'n_clicks_timestamp': 1611733454454},
+                   'out2-0': {'n_clicks': 8, 'n_clicks_timestamp': 1611733454654},
+                   'out3': {'n_clicks': 12, 'n_clicks_timestamp': 1611733455054},
+                   'out4': {'n_clicks': 16, 'n_clicks_timestamp': 1611733455454},
+                   'out5': {'n_clicks': 20, 'n_clicks_timestamp': 1611733455854},
+                   '{"_id":"inp-0","_type":"btn3"}': {'n_clicks': 10,
+                                                      'n_clicks_timestamp': 1615103039030},
+                   '{"_id":"inp-0","_type":"btn4"}': {'n_clicks': 14,
                                                       'n_clicks_timestamp': 1611733455154},
-                   '{"_id":"inp-2","_type":"btn5"}': {'n_clicks': 19,
-                                                      'n_clicks_timestamp': 1611733455554}}
+                   '{"_id":"inp-0","_type":"btn5"}': {'n_clicks': 18,
+                                                      'n_clicks_timestamp': 1611733455554},
+                   '{"_id":"inp-1","_type":"btn3"}': {'n_clicks': 11,
+                                                      'n_clicks_timestamp': 1615103039496},
+                   '{"_id":"inp-1","_type":"btn4"}': {'n_clicks': 15,
+                                                      'n_clicks_timestamp': 1611733455254},
+                   '{"_id":"inp-1","_type":"btn5"}': {'n_clicks': 19,
+                                                      'n_clicks_timestamp': 1611733455654},
+                   '{"_id":"inp-2","_type":"btn3"}': {'n_clicks': 12,
+                                                      'n_clicks_timestamp': 1615103040528},
+                   '{"_id":"inp-2","_type":"btn4"}': {'n_clicks': 15,
+                                                      'n_clicks_timestamp': 1611733455354},
+                   '{"_id":"inp-2","_type":"btn5"}': {'n_clicks': 20,
+                                                      'n_clicks_timestamp': 1611733455754}}
 
     assert DashApp.objects.get(instance_name="Some name").current_state() == final_state
 

--- a/django_plotly_dash/tests_dash_contract.json
+++ b/django_plotly_dash/tests_dash_contract.json
@@ -104,34 +104,6 @@
   },
   {
     "body": {
-      "output": "out2-0.children",
-      "outputs": {
-        "id": "out2-0",
-        "property": "children"
-      },
-      "inputs": [
-        {
-          "id": "inp2",
-          "property": "n_clicks_timestamp",
-          "value": 1611733454354
-        },
-        {
-          "id": "inp2",
-          "property": "n_clicks",
-          "value": 5
-        }
-      ],
-      "changedPropIds": []
-    },
-    "args": [
-      1611733454354,
-      5
-    ],
-    "kwargs": {},
-    "result": "multi triggered - (1611733454354, 5) - []"
-  },
-  {
-    "body": {
       "output": "out3.children",
       "outputs": {
         "id": "out3",
@@ -145,7 +117,7 @@
               "_type": "btn3"
             },
             "property": "n_clicks_timestamp",
-            "value": 1611733454554
+            "value": 1611733454754
           },
           {
             "id": {
@@ -153,7 +125,7 @@
               "_type": "btn3"
             },
             "property": "n_clicks_timestamp",
-            "value": 1611733454654
+            "value": 1611733454854
           },
           {
             "id": {
@@ -161,7 +133,7 @@
               "_type": "btn3"
             },
             "property": "n_clicks_timestamp",
-            "value": 1611733454754
+            "value": 1611733454954
           }
         ]
       ],
@@ -174,7 +146,7 @@
               "_type": "btn3"
             },
             "property": "n_clicks",
-            "value": 7
+            "value": 9
           },
           {
             "id": {
@@ -182,7 +154,7 @@
               "_type": "btn3"
             },
             "property": "n_clicks",
-            "value": 8
+            "value": 10
           },
           {
             "id": {
@@ -190,25 +162,53 @@
               "_type": "btn3"
             },
             "property": "n_clicks",
-            "value": 9
+            "value": 11
           }
         ]
       ]
     },
     "args": [
       [
-        1611733454554,
-        1611733454654,
-        1611733454754
+        1611733454754,
+        1611733454854,
+        1611733454954
       ],
       [
-        7,
-        8,
-        9
+        9,
+        10,
+        11
       ]
     ],
     "kwargs": {},
-    "result": "pattern ALL - ([1611733454554, 1611733454654, 1611733454754], [7, 8, 9])"
+    "result": "pattern ALL - ([1611733454754, 1611733454854, 1611733454954], [9, 10, 11])"
+  },
+  {
+    "body": {
+      "output": "out2-0.children",
+      "outputs": {
+        "id": "out2-0",
+        "property": "children"
+      },
+      "inputs": [
+        {
+          "id": "inp2",
+          "property": "n_clicks_timestamp",
+          "value": 1611733454554
+        },
+        {
+          "id": "inp2",
+          "property": "n_clicks",
+          "value": 7
+        }
+      ],
+      "changedPropIds": []
+    },
+    "args": [
+      1611733454554,
+      7
+    ],
+    "kwargs": {},
+    "result": "multi triggered - (1611733454554, 7) - []"
   },
   {
     "body": {
@@ -253,806 +253,11 @@
               "_type": "btn4"
             },
             "property": "n_clicks",
-            "value": 11
-          }
-        ]
-      ],
-      "changedPropIds": [],
-      "state": [
-        [
-          {
-            "id": {
-              "_id": "inp-0",
-              "_type": "btn4"
-            },
-            "property": "id",
-            "value": {
-              "_id": "inp-0",
-              "_type": "btn4"
-            }
-          }
-        ]
-      ]
-    },
-    "args": [
-      [
-        11
-      ],
-      [
-        {
-          "_id": "inp-0",
-          "_type": "btn4"
-        }
-      ]
-    ],
-    "kwargs": {},
-    "result": "pattern ALLSMALLER - ([11], [{'_id': 'inp-0', '_type': 'btn4'}])"
-  },
-  {
-    "body": {
-      "output": "{\"_id\":[\"MATCH\"],\"_type\":\"btn4\"}.children",
-      "outputs": {
-        "id": {
-          "_id": "inp-2",
-          "_type": "btn4"
-        },
-        "property": "children"
-      },
-      "inputs": [
-        [
-          {
-            "id": {
-              "_id": "inp-0",
-              "_type": "btn4"
-            },
-            "property": "n_clicks",
-            "value": 11
-          },
-          {
-            "id": {
-              "_id": "inp-1",
-              "_type": "btn4"
-            },
-            "property": "n_clicks",
-            "value": 12
-          }
-        ]
-      ],
-      "changedPropIds": [],
-      "state": [
-        [
-          {
-            "id": {
-              "_id": "inp-0",
-              "_type": "btn4"
-            },
-            "property": "id",
-            "value": {
-              "_id": "inp-0",
-              "_type": "btn4"
-            }
-          },
-          {
-            "id": {
-              "_id": "inp-1",
-              "_type": "btn4"
-            },
-            "property": "id",
-            "value": {
-              "_id": "inp-1",
-              "_type": "btn4"
-            }
-          }
-        ]
-      ]
-    },
-    "args": [
-      [
-        11,
-        12
-      ],
-      [
-        {
-          "_id": "inp-0",
-          "_type": "btn4"
-        },
-        {
-          "_id": "inp-1",
-          "_type": "btn4"
-        }
-      ]
-    ],
-    "kwargs": {},
-    "result": "pattern ALLSMALLER - ([11, 12], [{'_id': 'inp-0', '_type': 'btn4'}, {'_id': 'inp-1', '_type': 'btn4'}])"
-  },
-  {
-    "body": {
-      "output": "{\"_id\":[\"MATCH\"],\"_type\":\"btn5\"}.children",
-      "outputs": {
-        "id": {
-          "_id": "inp-0",
-          "_type": "btn5"
-        },
-        "property": "children"
-      },
-      "inputs": [
-        {
-          "id": {
-            "_id": "inp-0",
-            "_type": "btn5"
-          },
-          "property": "n_clicks",
-          "value": 15
-        }
-      ],
-      "changedPropIds": [],
-      "state": [
-        {
-          "id": {
-            "_id": "inp-0",
-            "_type": "btn5"
-          },
-          "property": "id",
-          "value": {
-            "_id": "inp-0",
-            "_type": "btn5"
-          }
-        }
-      ]
-    },
-    "args": [
-      15,
-      {
-        "_id": "inp-0",
-        "_type": "btn5"
-      }
-    ],
-    "kwargs": {},
-    "result": "pattern MATCH - (15, {'_id': 'inp-0', '_type': 'btn5'})"
-  },
-  {
-    "body": {
-      "output": "{\"_id\":[\"MATCH\"],\"_type\":\"btn5\"}.children",
-      "outputs": {
-        "id": {
-          "_id": "inp-1",
-          "_type": "btn5"
-        },
-        "property": "children"
-      },
-      "inputs": [
-        {
-          "id": {
-            "_id": "inp-1",
-            "_type": "btn5"
-          },
-          "property": "n_clicks",
-          "value": 16
-        }
-      ],
-      "changedPropIds": [],
-      "state": [
-        {
-          "id": {
-            "_id": "inp-1",
-            "_type": "btn5"
-          },
-          "property": "id",
-          "value": {
-            "_id": "inp-1",
-            "_type": "btn5"
-          }
-        }
-      ]
-    },
-    "args": [
-      16,
-      {
-        "_id": "inp-1",
-        "_type": "btn5"
-      }
-    ],
-    "kwargs": {},
-    "result": "pattern MATCH - (16, {'_id': 'inp-1', '_type': 'btn5'})"
-  },
-  {
-    "body": {
-      "output": "{\"_id\":[\"MATCH\"],\"_type\":\"btn5\"}.children",
-      "outputs": {
-        "id": {
-          "_id": "inp-2",
-          "_type": "btn5"
-        },
-        "property": "children"
-      },
-      "inputs": [
-        {
-          "id": {
-            "_id": "inp-2",
-            "_type": "btn5"
-          },
-          "property": "n_clicks",
-          "value": 17
-        }
-      ],
-      "changedPropIds": [],
-      "state": [
-        {
-          "id": {
-            "_id": "inp-2",
-            "_type": "btn5"
-          },
-          "property": "id",
-          "value": {
-            "_id": "inp-2",
-            "_type": "btn5"
-          }
-        }
-      ]
-    },
-    "args": [
-      17,
-      {
-        "_id": "inp-2",
-        "_type": "btn5"
-      }
-    ],
-    "kwargs": {},
-    "result": "pattern MATCH - (17, {'_id': 'inp-2', '_type': 'btn5'})"
-  },
-  {
-    "body": {
-      "output": "out1-0.children",
-      "outputs": {
-        "id": "out1-0",
-        "property": "children"
-      },
-      "inputs": [
-        {
-          "id": "inp1",
-          "property": "n_clicks_timestamp",
-          "value": 1611736145932
-        }
-      ],
-      "changedPropIds": [
-        "inp1.n_clicks_timestamp"
-      ],
-      "state": [
-        {
-          "id": "inp1",
-          "property": "n_clicks",
-          "value": 1
-        }
-      ]
-    },
-    "args": [
-      1611736145932,
-      1
-    ],
-    "kwargs": {},
-    "result": "single - (1611736145932, 1)"
-  },
-  {
-    "body": {
-      "output": "..out1-1.children..",
-      "outputs": [
-        {
-          "id": "out1-1",
-          "property": "children"
-        }
-      ],
-      "inputs": [
-        {
-          "id": "inp1",
-          "property": "n_clicks_timestamp",
-          "value": 1611736145932
-        }
-      ],
-      "changedPropIds": [
-        "inp1.n_clicks_timestamp"
-      ],
-      "state": [
-        {
-          "id": "inp1",
-          "property": "n_clicks",
-          "value": 1
-        }
-      ]
-    },
-    "args": [
-      1611736145932,
-      1
-    ],
-    "kwargs": {},
-    "result": [
-      "single in list - (1611736145932, 1)"
-    ]
-  },
-  {
-    "body": {
-      "output": "..out1-2.children...out1-3.children..",
-      "outputs": [
-        {
-          "id": "out1-2",
-          "property": "children"
-        },
-        {
-          "id": "out1-3",
-          "property": "children"
-        }
-      ],
-      "inputs": [
-        {
-          "id": "inp1",
-          "property": "n_clicks_timestamp",
-          "value": 1611736145932
-        }
-      ],
-      "changedPropIds": [
-        "inp1.n_clicks_timestamp"
-      ],
-      "state": [
-        {
-          "id": "inp1",
-          "property": "n_clicks",
-          "value": 1
-        }
-      ]
-    },
-    "args": [
-      1611736145932,
-      1
-    ],
-    "kwargs": {},
-    "result": [
-      "multi in list - (1611736145932, 1)",
-      "multi in list - (1611736145932, 1)"
-    ]
-  },
-  {
-    "body": {
-      "output": "out2-0.children",
-      "outputs": {
-        "id": "out2-0",
-        "property": "children"
-      },
-      "inputs": [
-        {
-          "id": "inp2",
-          "property": "n_clicks_timestamp",
-          "value": 1611736146875
-        },
-        {
-          "id": "inp2",
-          "property": "n_clicks",
-          "value": 6
-        }
-      ],
-      "changedPropIds": [
-        "inp2.n_clicks",
-        "inp2.n_clicks_timestamp"
-      ]
-    },
-    "args": [
-      1611736146875,
-      6
-    ],
-    "kwargs": {},
-    "result": "multi triggered - (1611736146875, 6) - [{'prop_id': 'inp2.n_clicks', 'value': 6}, {'prop_id': 'inp2.n_clicks_timestamp', 'value': 1611736146875}]"
-  },
-  {
-    "body": {
-      "output": "out3.children",
-      "outputs": {
-        "id": "out3",
-        "property": "children"
-      },
-      "inputs": [
-        [
-          {
-            "id": {
-              "_id": "inp-0",
-              "_type": "btn3"
-            },
-            "property": "n_clicks_timestamp",
-            "value": 1611736147644
-          },
-          {
-            "id": {
-              "_id": "inp-1",
-              "_type": "btn3"
-            },
-            "property": "n_clicks_timestamp",
-            "value": 1611733454654
-          },
-          {
-            "id": {
-              "_id": "inp-2",
-              "_type": "btn3"
-            },
-            "property": "n_clicks_timestamp",
-            "value": 1611733454754
-          }
-        ]
-      ],
-      "changedPropIds": [
-        "{\"_id\":\"inp-0\",\"_type\":\"btn3\"}.n_clicks_timestamp"
-      ],
-      "state": [
-        [
-          {
-            "id": {
-              "_id": "inp-0",
-              "_type": "btn3"
-            },
-            "property": "n_clicks",
-            "value": 8
-          },
-          {
-            "id": {
-              "_id": "inp-1",
-              "_type": "btn3"
-            },
-            "property": "n_clicks",
-            "value": 8
-          },
-          {
-            "id": {
-              "_id": "inp-2",
-              "_type": "btn3"
-            },
-            "property": "n_clicks",
-            "value": 9
-          }
-        ]
-      ]
-    },
-    "args": [
-      [
-        1611736147644,
-        1611733454654,
-        1611733454754
-      ],
-      [
-        8,
-        8,
-        9
-      ]
-    ],
-    "kwargs": {},
-    "result": "pattern ALL - ([1611736147644, 1611733454654, 1611733454754], [8, 8, 9])"
-  },
-  {
-    "body": {
-      "output": "out3.children",
-      "outputs": {
-        "id": "out3",
-        "property": "children"
-      },
-      "inputs": [
-        [
-          {
-            "id": {
-              "_id": "inp-0",
-              "_type": "btn3"
-            },
-            "property": "n_clicks_timestamp",
-            "value": 1611736147644
-          },
-          {
-            "id": {
-              "_id": "inp-1",
-              "_type": "btn3"
-            },
-            "property": "n_clicks_timestamp",
-            "value": 1611736148172
-          },
-          {
-            "id": {
-              "_id": "inp-2",
-              "_type": "btn3"
-            },
-            "property": "n_clicks_timestamp",
-            "value": 1611733454754
-          }
-        ]
-      ],
-      "changedPropIds": [
-        "{\"_id\":\"inp-1\",\"_type\":\"btn3\"}.n_clicks_timestamp"
-      ],
-      "state": [
-        [
-          {
-            "id": {
-              "_id": "inp-0",
-              "_type": "btn3"
-            },
-            "property": "n_clicks",
-            "value": 8
-          },
-          {
-            "id": {
-              "_id": "inp-1",
-              "_type": "btn3"
-            },
-            "property": "n_clicks",
-            "value": 9
-          },
-          {
-            "id": {
-              "_id": "inp-2",
-              "_type": "btn3"
-            },
-            "property": "n_clicks",
-            "value": 9
-          }
-        ]
-      ]
-    },
-    "args": [
-      [
-        1611736147644,
-        1611736148172,
-        1611733454754
-      ],
-      [
-        8,
-        9,
-        9
-      ]
-    ],
-    "kwargs": {},
-    "result": "pattern ALL - ([1611736147644, 1611736148172, 1611733454754], [8, 9, 9])"
-  },
-  {
-    "body": {
-      "output": "out3.children",
-      "outputs": {
-        "id": "out3",
-        "property": "children"
-      },
-      "inputs": [
-        [
-          {
-            "id": {
-              "_id": "inp-0",
-              "_type": "btn3"
-            },
-            "property": "n_clicks_timestamp",
-            "value": 1611736147644
-          },
-          {
-            "id": {
-              "_id": "inp-1",
-              "_type": "btn3"
-            },
-            "property": "n_clicks_timestamp",
-            "value": 1611736148172
-          },
-          {
-            "id": {
-              "_id": "inp-2",
-              "_type": "btn3"
-            },
-            "property": "n_clicks_timestamp",
-            "value": 1611736149140
-          }
-        ]
-      ],
-      "changedPropIds": [
-        "{\"_id\":\"inp-2\",\"_type\":\"btn3\"}.n_clicks_timestamp"
-      ],
-      "state": [
-        [
-          {
-            "id": {
-              "_id": "inp-0",
-              "_type": "btn3"
-            },
-            "property": "n_clicks",
-            "value": 8
-          },
-          {
-            "id": {
-              "_id": "inp-1",
-              "_type": "btn3"
-            },
-            "property": "n_clicks",
-            "value": 9
-          },
-          {
-            "id": {
-              "_id": "inp-2",
-              "_type": "btn3"
-            },
-            "property": "n_clicks",
-            "value": 10
-          }
-        ]
-      ]
-    },
-    "args": [
-      [
-        1611736147644,
-        1611736148172,
-        1611736149140
-      ],
-      [
-        8,
-        9,
-        10
-      ]
-    ],
-    "kwargs": {},
-    "result": "pattern ALL - ([1611736147644, 1611736148172, 1611736149140], [8, 9, 10])"
-  },
-  {
-    "body": {
-      "output": "{\"_id\":[\"MATCH\"],\"_type\":\"btn4\"}.children",
-      "outputs": {
-        "id": {
-          "_id": "inp-1",
-          "_type": "btn4"
-        },
-        "property": "children"
-      },
-      "inputs": [
-        [
-          {
-            "id": {
-              "_id": "inp-0",
-              "_type": "btn4"
-            },
-            "property": "n_clicks",
-            "value": 12
-          }
-        ]
-      ],
-      "changedPropIds": [
-        "{\"_id\":\"inp-0\",\"_type\":\"btn4\"}.n_clicks"
-      ],
-      "state": [
-        [
-          {
-            "id": {
-              "_id": "inp-0",
-              "_type": "btn4"
-            },
-            "property": "id",
-            "value": {
-              "_id": "inp-0",
-              "_type": "btn4"
-            }
-          }
-        ]
-      ]
-    },
-    "args": [
-      [
-        12
-      ],
-      [
-        {
-          "_id": "inp-0",
-          "_type": "btn4"
-        }
-      ]
-    ],
-    "kwargs": {},
-    "result": "pattern ALLSMALLER - ([12], [{'_id': 'inp-0', '_type': 'btn4'}])"
-  },
-  {
-    "body": {
-      "output": "{\"_id\":[\"MATCH\"],\"_type\":\"btn4\"}.children",
-      "outputs": {
-        "id": {
-          "_id": "inp-2",
-          "_type": "btn4"
-        },
-        "property": "children"
-      },
-      "inputs": [
-        [
-          {
-            "id": {
-              "_id": "inp-0",
-              "_type": "btn4"
-            },
-            "property": "n_clicks",
-            "value": 12
-          },
-          {
-            "id": {
-              "_id": "inp-1",
-              "_type": "btn4"
-            },
-            "property": "n_clicks",
-            "value": 12
-          }
-        ]
-      ],
-      "changedPropIds": [
-        "{\"_id\":\"inp-0\",\"_type\":\"btn4\"}.n_clicks"
-      ],
-      "state": [
-        [
-          {
-            "id": {
-              "_id": "inp-0",
-              "_type": "btn4"
-            },
-            "property": "id",
-            "value": {
-              "_id": "inp-0",
-              "_type": "btn4"
-            }
-          },
-          {
-            "id": {
-              "_id": "inp-1",
-              "_type": "btn4"
-            },
-            "property": "id",
-            "value": {
-              "_id": "inp-1",
-              "_type": "btn4"
-            }
-          }
-        ]
-      ]
-    },
-    "args": [
-      [
-        12,
-        12
-      ],
-      [
-        {
-          "_id": "inp-0",
-          "_type": "btn4"
-        },
-        {
-          "_id": "inp-1",
-          "_type": "btn4"
-        }
-      ]
-    ],
-    "kwargs": {},
-    "result": "pattern ALLSMALLER - ([12, 12], [{'_id': 'inp-0', '_type': 'btn4'}, {'_id': 'inp-1', '_type': 'btn4'}])"
-  },
-  {
-    "body": {
-      "output": "{\"_id\":[\"MATCH\"],\"_type\":\"btn4\"}.children",
-      "outputs": {
-        "id": {
-          "_id": "inp-2",
-          "_type": "btn4"
-        },
-        "property": "children"
-      },
-      "inputs": [
-        [
-          {
-            "id": {
-              "_id": "inp-0",
-              "_type": "btn4"
-            },
-            "property": "n_clicks",
-            "value": 12
-          },
-          {
-            "id": {
-              "_id": "inp-1",
-              "_type": "btn4"
-            },
-            "property": "n_clicks",
             "value": 13
           }
         ]
       ],
-      "changedPropIds": [
-        "{\"_id\":\"inp-1\",\"_type\":\"btn4\"}.n_clicks"
-      ],
+      "changedPropIds": [],
       "state": [
         [
           {
@@ -1065,30 +270,91 @@
               "_id": "inp-0",
               "_type": "btn4"
             }
-          },
-          {
-            "id": {
-              "_id": "inp-1",
-              "_type": "btn4"
-            },
-            "property": "id",
-            "value": {
-              "_id": "inp-1",
-              "_type": "btn4"
-            }
           }
         ]
       ]
     },
     "args": [
       [
-        12,
         13
       ],
       [
         {
           "_id": "inp-0",
           "_type": "btn4"
+        }
+      ]
+    ],
+    "kwargs": {},
+    "result": "pattern ALLSMALLER - ([13], [{'_id': 'inp-0', '_type': 'btn4'}])"
+  },
+  {
+    "body": {
+      "output": "{\"_id\":[\"MATCH\"],\"_type\":\"btn4\"}.children",
+      "outputs": {
+        "id": {
+          "_id": "inp-2",
+          "_type": "btn4"
+        },
+        "property": "children"
+      },
+      "inputs": [
+        [
+          {
+            "id": {
+              "_id": "inp-0",
+              "_type": "btn4"
+            },
+            "property": "n_clicks",
+            "value": 13
+          },
+          {
+            "id": {
+              "_id": "inp-1",
+              "_type": "btn4"
+            },
+            "property": "n_clicks",
+            "value": 14
+          }
+        ]
+      ],
+      "changedPropIds": [],
+      "state": [
+        [
+          {
+            "id": {
+              "_id": "inp-0",
+              "_type": "btn4"
+            },
+            "property": "id",
+            "value": {
+              "_id": "inp-0",
+              "_type": "btn4"
+            }
+          },
+          {
+            "id": {
+              "_id": "inp-1",
+              "_type": "btn4"
+            },
+            "property": "id",
+            "value": {
+              "_id": "inp-1",
+              "_type": "btn4"
+            }
+          }
+        ]
+      ]
+    },
+    "args": [
+      [
+        13,
+        14
+      ],
+      [
+        {
+          "_id": "inp-0",
+          "_type": "btn4"
         },
         {
           "_id": "inp-1",
@@ -1097,7 +363,7 @@
       ]
     ],
     "kwargs": {},
-    "result": "pattern ALLSMALLER - ([12, 13], [{'_id': 'inp-0', '_type': 'btn4'}, {'_id': 'inp-1', '_type': 'btn4'}])"
+    "result": "pattern ALLSMALLER - ([13, 14], [{'_id': 'inp-0', '_type': 'btn4'}, {'_id': 'inp-1', '_type': 'btn4'}])"
   },
   {
     "body": {
@@ -1116,68 +382,19 @@
             "_type": "btn5"
           },
           "property": "n_clicks",
-          "value": 16
-        }
-      ],
-      "changedPropIds": [
-        "{\"_id\":\"inp-0\",\"_type\":\"btn5\"}.n_clicks"
-      ],
-      "state": [
-        {
-          "id": {
-            "_id": "inp-0",
-            "_type": "btn5"
-          },
-          "property": "id",
-          "value": {
-            "_id": "inp-0",
-            "_type": "btn5"
-          }
-        }
-      ]
-    },
-    "args": [
-      16,
-      {
-        "_id": "inp-0",
-        "_type": "btn5"
-      }
-    ],
-    "kwargs": {},
-    "result": "pattern MATCH - (16, {'_id': 'inp-0', '_type': 'btn5'})"
-  },
-  {
-    "body": {
-      "output": "{\"_id\":[\"MATCH\"],\"_type\":\"btn5\"}.children",
-      "outputs": {
-        "id": {
-          "_id": "inp-1",
-          "_type": "btn5"
-        },
-        "property": "children"
-      },
-      "inputs": [
-        {
-          "id": {
-            "_id": "inp-1",
-            "_type": "btn5"
-          },
-          "property": "n_clicks",
           "value": 17
         }
       ],
-      "changedPropIds": [
-        "{\"_id\":\"inp-1\",\"_type\":\"btn5\"}.n_clicks"
-      ],
+      "changedPropIds": [],
       "state": [
         {
           "id": {
-            "_id": "inp-1",
+            "_id": "inp-0",
             "_type": "btn5"
           },
           "property": "id",
           "value": {
-            "_id": "inp-1",
+            "_id": "inp-0",
             "_type": "btn5"
           }
         }
@@ -1186,12 +403,12 @@
     "args": [
       17,
       {
-        "_id": "inp-1",
+        "_id": "inp-0",
         "_type": "btn5"
       }
     ],
     "kwargs": {},
-    "result": "pattern MATCH - (17, {'_id': 'inp-1', '_type': 'btn5'})"
+    "result": "pattern MATCH - (17, {'_id': 'inp-0', '_type': 'btn5'})"
   },
   {
     "body": {
@@ -1213,9 +430,7 @@
           "value": 18
         }
       ],
-      "changedPropIds": [
-        "{\"_id\":\"inp-1\",\"_type\":\"btn5\"}.n_clicks"
-      ],
+      "changedPropIds": [],
       "state": [
         {
           "id": {
@@ -1257,59 +472,10 @@
             "_type": "btn5"
           },
           "property": "n_clicks",
-          "value": 18
-        }
-      ],
-      "changedPropIds": [
-        "{\"_id\":\"inp-2\",\"_type\":\"btn5\"}.n_clicks"
-      ],
-      "state": [
-        {
-          "id": {
-            "_id": "inp-2",
-            "_type": "btn5"
-          },
-          "property": "id",
-          "value": {
-            "_id": "inp-2",
-            "_type": "btn5"
-          }
-        }
-      ]
-    },
-    "args": [
-      18,
-      {
-        "_id": "inp-2",
-        "_type": "btn5"
-      }
-    ],
-    "kwargs": {},
-    "result": "pattern MATCH - (18, {'_id': 'inp-2', '_type': 'btn5'})"
-  },
-  {
-    "body": {
-      "output": "{\"_id\":[\"MATCH\"],\"_type\":\"btn5\"}.children",
-      "outputs": {
-        "id": {
-          "_id": "inp-2",
-          "_type": "btn5"
-        },
-        "property": "children"
-      },
-      "inputs": [
-        {
-          "id": {
-            "_id": "inp-2",
-            "_type": "btn5"
-          },
-          "property": "n_clicks",
           "value": 19
         }
       ],
-      "changedPropIds": [
-        "{\"_id\":\"inp-2\",\"_type\":\"btn5\"}.n_clicks"
-      ],
+      "changedPropIds": [],
       "state": [
         {
           "id": {
@@ -1333,5 +499,842 @@
     ],
     "kwargs": {},
     "result": "pattern MATCH - (19, {'_id': 'inp-2', '_type': 'btn5'})"
+  },
+  {
+    "body": {
+      "output": "..out1b.href...out1b.children..",
+      "outputs": [
+        {
+          "id": "out1b",
+          "property": "href"
+        },
+        {
+          "id": "out1b",
+          "property": "children"
+        }
+      ],
+      "inputs": [
+        {
+          "id": "inp1b",
+          "property": "n_clicks_timestamp",
+          "value": 1611733454354
+        }
+      ],
+      "changedPropIds": []
+    },
+    "args": [
+      1611733454354
+    ],
+    "kwargs": {},
+    "result": [
+      "http://www.example.com/1611733454354",
+      "http://www.example.com/1611733454354"
+    ]
+  },
+  {
+    "body": {
+      "output": "out1-0.children",
+      "outputs": {
+        "id": "out1-0",
+        "property": "children"
+      },
+      "inputs": [
+        {
+          "id": "inp1",
+          "property": "n_clicks_timestamp",
+          "value": 1615103027288
+        }
+      ],
+      "changedPropIds": [
+        "inp1.n_clicks_timestamp"
+      ],
+      "state": [
+        {
+          "id": "inp1",
+          "property": "n_clicks",
+          "value": 1
+        }
+      ]
+    },
+    "args": [
+      1615103027288,
+      1
+    ],
+    "kwargs": {},
+    "result": "single - (1615103027288, 1)"
+  },
+  {
+    "body": {
+      "output": "..out1-2.children...out1-3.children..",
+      "outputs": [
+        {
+          "id": "out1-2",
+          "property": "children"
+        },
+        {
+          "id": "out1-3",
+          "property": "children"
+        }
+      ],
+      "inputs": [
+        {
+          "id": "inp1",
+          "property": "n_clicks_timestamp",
+          "value": 1615103027288
+        }
+      ],
+      "changedPropIds": [
+        "inp1.n_clicks_timestamp"
+      ],
+      "state": [
+        {
+          "id": "inp1",
+          "property": "n_clicks",
+          "value": 1
+        }
+      ]
+    },
+    "args": [
+      1615103027288,
+      1
+    ],
+    "kwargs": {},
+    "result": [
+      "multi in list - (1615103027288, 1)",
+      "multi in list - (1615103027288, 1)"
+    ]
+  },
+  {
+    "body": {
+      "output": "..out1-1.children..",
+      "outputs": [
+        {
+          "id": "out1-1",
+          "property": "children"
+        }
+      ],
+      "inputs": [
+        {
+          "id": "inp1",
+          "property": "n_clicks_timestamp",
+          "value": 1615103027288
+        }
+      ],
+      "changedPropIds": [
+        "inp1.n_clicks_timestamp"
+      ],
+      "state": [
+        {
+          "id": "inp1",
+          "property": "n_clicks",
+          "value": 1
+        }
+      ]
+    },
+    "args": [
+      1615103027288,
+      1
+    ],
+    "kwargs": {},
+    "result": [
+      "single in list - (1615103027288, 1)"
+    ]
+  },
+  {
+    "body": {
+      "output": "..out1b.href...out1b.children..",
+      "outputs": [
+        {
+          "id": "out1b",
+          "property": "href"
+        },
+        {
+          "id": "out1b",
+          "property": "children"
+        }
+      ],
+      "inputs": [
+        {
+          "id": "inp1b",
+          "property": "n_clicks_timestamp",
+          "value": 1615103033444
+        }
+      ],
+      "changedPropIds": [
+        "inp1b.n_clicks_timestamp"
+      ]
+    },
+    "args": [
+      1615103033444
+    ],
+    "kwargs": {},
+    "result": [
+      "http://www.example.com/1615103033444",
+      "http://www.example.com/1615103033444"
+    ]
+  },
+  {
+    "body": {
+      "output": "..out1b.href...out1b.children..",
+      "outputs": [
+        {
+          "id": "out1b",
+          "property": "href"
+        },
+        {
+          "id": "out1b",
+          "property": "children"
+        }
+      ],
+      "inputs": [
+        {
+          "id": "inp1b",
+          "property": "n_clicks_timestamp",
+          "value": 1615103033482
+        }
+      ],
+      "changedPropIds": [
+        "inp1b.n_clicks_timestamp"
+      ]
+    },
+    "args": [
+      1615103033482
+    ],
+    "kwargs": {},
+    "result": [
+      "http://www.example.com/1615103033482",
+      "http://www.example.com/1615103033482"
+    ]
+  },
+  {
+    "body": {
+      "output": "out2-0.children",
+      "outputs": {
+        "id": "out2-0",
+        "property": "children"
+      },
+      "inputs": [
+        {
+          "id": "inp2",
+          "property": "n_clicks_timestamp",
+          "value": 1615103036591
+        },
+        {
+          "id": "inp2",
+          "property": "n_clicks",
+          "value": 8
+        }
+      ],
+      "changedPropIds": [
+        "inp2.n_clicks",
+        "inp2.n_clicks_timestamp"
+      ]
+    },
+    "args": [
+      1615103036591,
+      8
+    ],
+    "kwargs": {},
+    "result": "multi triggered - (1615103036591, 8) - [{'prop_id': 'inp2.n_clicks', 'value': 8}, {'prop_id': 'inp2.n_clicks_timestamp', 'value': 1615103036591}]"
+  },
+  {
+    "body": {
+      "output": "out3.children",
+      "outputs": {
+        "id": "out3",
+        "property": "children"
+      },
+      "inputs": [
+        [
+          {
+            "id": {
+              "_id": "inp-0",
+              "_type": "btn3"
+            },
+            "property": "n_clicks_timestamp",
+            "value": 1615103039030
+          },
+          {
+            "id": {
+              "_id": "inp-1",
+              "_type": "btn3"
+            },
+            "property": "n_clicks_timestamp",
+            "value": 1611733454854
+          },
+          {
+            "id": {
+              "_id": "inp-2",
+              "_type": "btn3"
+            },
+            "property": "n_clicks_timestamp",
+            "value": 1611733454954
+          }
+        ]
+      ],
+      "changedPropIds": [
+        "{\"_id\":\"inp-0\",\"_type\":\"btn3\"}.n_clicks_timestamp"
+      ],
+      "state": [
+        [
+          {
+            "id": {
+              "_id": "inp-0",
+              "_type": "btn3"
+            },
+            "property": "n_clicks",
+            "value": 10
+          },
+          {
+            "id": {
+              "_id": "inp-1",
+              "_type": "btn3"
+            },
+            "property": "n_clicks",
+            "value": 10
+          },
+          {
+            "id": {
+              "_id": "inp-2",
+              "_type": "btn3"
+            },
+            "property": "n_clicks",
+            "value": 11
+          }
+        ]
+      ]
+    },
+    "args": [
+      [
+        1615103039030,
+        1611733454854,
+        1611733454954
+      ],
+      [
+        10,
+        10,
+        11
+      ]
+    ],
+    "kwargs": {},
+    "result": "pattern ALL - ([1615103039030, 1611733454854, 1611733454954], [10, 10, 11])"
+  },
+  {
+    "body": {
+      "output": "out3.children",
+      "outputs": {
+        "id": "out3",
+        "property": "children"
+      },
+      "inputs": [
+        [
+          {
+            "id": {
+              "_id": "inp-0",
+              "_type": "btn3"
+            },
+            "property": "n_clicks_timestamp",
+            "value": 1615103039030
+          },
+          {
+            "id": {
+              "_id": "inp-1",
+              "_type": "btn3"
+            },
+            "property": "n_clicks_timestamp",
+            "value": 1615103039496
+          },
+          {
+            "id": {
+              "_id": "inp-2",
+              "_type": "btn3"
+            },
+            "property": "n_clicks_timestamp",
+            "value": 1611733454954
+          }
+        ]
+      ],
+      "changedPropIds": [
+        "{\"_id\":\"inp-1\",\"_type\":\"btn3\"}.n_clicks_timestamp"
+      ],
+      "state": [
+        [
+          {
+            "id": {
+              "_id": "inp-0",
+              "_type": "btn3"
+            },
+            "property": "n_clicks",
+            "value": 10
+          },
+          {
+            "id": {
+              "_id": "inp-1",
+              "_type": "btn3"
+            },
+            "property": "n_clicks",
+            "value": 11
+          },
+          {
+            "id": {
+              "_id": "inp-2",
+              "_type": "btn3"
+            },
+            "property": "n_clicks",
+            "value": 11
+          }
+        ]
+      ]
+    },
+    "args": [
+      [
+        1615103039030,
+        1615103039496,
+        1611733454954
+      ],
+      [
+        10,
+        11,
+        11
+      ]
+    ],
+    "kwargs": {},
+    "result": "pattern ALL - ([1615103039030, 1615103039496, 1611733454954], [10, 11, 11])"
+  },
+  {
+    "body": {
+      "output": "out3.children",
+      "outputs": {
+        "id": "out3",
+        "property": "children"
+      },
+      "inputs": [
+        [
+          {
+            "id": {
+              "_id": "inp-0",
+              "_type": "btn3"
+            },
+            "property": "n_clicks_timestamp",
+            "value": 1615103039030
+          },
+          {
+            "id": {
+              "_id": "inp-1",
+              "_type": "btn3"
+            },
+            "property": "n_clicks_timestamp",
+            "value": 1615103039496
+          },
+          {
+            "id": {
+              "_id": "inp-2",
+              "_type": "btn3"
+            },
+            "property": "n_clicks_timestamp",
+            "value": 1615103040528
+          }
+        ]
+      ],
+      "changedPropIds": [
+        "{\"_id\":\"inp-2\",\"_type\":\"btn3\"}.n_clicks_timestamp"
+      ],
+      "state": [
+        [
+          {
+            "id": {
+              "_id": "inp-0",
+              "_type": "btn3"
+            },
+            "property": "n_clicks",
+            "value": 10
+          },
+          {
+            "id": {
+              "_id": "inp-1",
+              "_type": "btn3"
+            },
+            "property": "n_clicks",
+            "value": 11
+          },
+          {
+            "id": {
+              "_id": "inp-2",
+              "_type": "btn3"
+            },
+            "property": "n_clicks",
+            "value": 12
+          }
+        ]
+      ]
+    },
+    "args": [
+      [
+        1615103039030,
+        1615103039496,
+        1615103040528
+      ],
+      [
+        10,
+        11,
+        12
+      ]
+    ],
+    "kwargs": {},
+    "result": "pattern ALL - ([1615103039030, 1615103039496, 1615103040528], [10, 11, 12])"
+  },
+  {
+    "body": {
+      "output": "{\"_id\":[\"MATCH\"],\"_type\":\"btn4\"}.children",
+      "outputs": {
+        "id": {
+          "_id": "inp-1",
+          "_type": "btn4"
+        },
+        "property": "children"
+      },
+      "inputs": [
+        [
+          {
+            "id": {
+              "_id": "inp-0",
+              "_type": "btn4"
+            },
+            "property": "n_clicks",
+            "value": 14
+          }
+        ]
+      ],
+      "changedPropIds": [
+        "{\"_id\":\"inp-0\",\"_type\":\"btn4\"}.n_clicks"
+      ],
+      "state": [
+        [
+          {
+            "id": {
+              "_id": "inp-0",
+              "_type": "btn4"
+            },
+            "property": "id",
+            "value": {
+              "_id": "inp-0",
+              "_type": "btn4"
+            }
+          }
+        ]
+      ]
+    },
+    "args": [
+      [
+        14
+      ],
+      [
+        {
+          "_id": "inp-0",
+          "_type": "btn4"
+        }
+      ]
+    ],
+    "kwargs": {},
+    "result": "pattern ALLSMALLER - ([14], [{'_id': 'inp-0', '_type': 'btn4'}])"
+  },
+  {
+    "body": {
+      "output": "{\"_id\":[\"MATCH\"],\"_type\":\"btn4\"}.children",
+      "outputs": {
+        "id": {
+          "_id": "inp-2",
+          "_type": "btn4"
+        },
+        "property": "children"
+      },
+      "inputs": [
+        [
+          {
+            "id": {
+              "_id": "inp-0",
+              "_type": "btn4"
+            },
+            "property": "n_clicks",
+            "value": 14
+          },
+          {
+            "id": {
+              "_id": "inp-1",
+              "_type": "btn4"
+            },
+            "property": "n_clicks",
+            "value": 14
+          }
+        ]
+      ],
+      "changedPropIds": [
+        "{\"_id\":\"inp-0\",\"_type\":\"btn4\"}.n_clicks"
+      ],
+      "state": [
+        [
+          {
+            "id": {
+              "_id": "inp-0",
+              "_type": "btn4"
+            },
+            "property": "id",
+            "value": {
+              "_id": "inp-0",
+              "_type": "btn4"
+            }
+          },
+          {
+            "id": {
+              "_id": "inp-1",
+              "_type": "btn4"
+            },
+            "property": "id",
+            "value": {
+              "_id": "inp-1",
+              "_type": "btn4"
+            }
+          }
+        ]
+      ]
+    },
+    "args": [
+      [
+        14,
+        14
+      ],
+      [
+        {
+          "_id": "inp-0",
+          "_type": "btn4"
+        },
+        {
+          "_id": "inp-1",
+          "_type": "btn4"
+        }
+      ]
+    ],
+    "kwargs": {},
+    "result": "pattern ALLSMALLER - ([14, 14], [{'_id': 'inp-0', '_type': 'btn4'}, {'_id': 'inp-1', '_type': 'btn4'}])"
+  },
+  {
+    "body": {
+      "output": "{\"_id\":[\"MATCH\"],\"_type\":\"btn4\"}.children",
+      "outputs": {
+        "id": {
+          "_id": "inp-2",
+          "_type": "btn4"
+        },
+        "property": "children"
+      },
+      "inputs": [
+        [
+          {
+            "id": {
+              "_id": "inp-0",
+              "_type": "btn4"
+            },
+            "property": "n_clicks",
+            "value": 14
+          },
+          {
+            "id": {
+              "_id": "inp-1",
+              "_type": "btn4"
+            },
+            "property": "n_clicks",
+            "value": 15
+          }
+        ]
+      ],
+      "changedPropIds": [
+        "{\"_id\":\"inp-1\",\"_type\":\"btn4\"}.n_clicks"
+      ],
+      "state": [
+        [
+          {
+            "id": {
+              "_id": "inp-0",
+              "_type": "btn4"
+            },
+            "property": "id",
+            "value": {
+              "_id": "inp-0",
+              "_type": "btn4"
+            }
+          },
+          {
+            "id": {
+              "_id": "inp-1",
+              "_type": "btn4"
+            },
+            "property": "id",
+            "value": {
+              "_id": "inp-1",
+              "_type": "btn4"
+            }
+          }
+        ]
+      ]
+    },
+    "args": [
+      [
+        14,
+        15
+      ],
+      [
+        {
+          "_id": "inp-0",
+          "_type": "btn4"
+        },
+        {
+          "_id": "inp-1",
+          "_type": "btn4"
+        }
+      ]
+    ],
+    "kwargs": {},
+    "result": "pattern ALLSMALLER - ([14, 15], [{'_id': 'inp-0', '_type': 'btn4'}, {'_id': 'inp-1', '_type': 'btn4'}])"
+  },
+  {
+    "body": {
+      "output": "{\"_id\":[\"MATCH\"],\"_type\":\"btn5\"}.children",
+      "outputs": {
+        "id": {
+          "_id": "inp-0",
+          "_type": "btn5"
+        },
+        "property": "children"
+      },
+      "inputs": [
+        {
+          "id": {
+            "_id": "inp-0",
+            "_type": "btn5"
+          },
+          "property": "n_clicks",
+          "value": 18
+        }
+      ],
+      "changedPropIds": [
+        "{\"_id\":\"inp-0\",\"_type\":\"btn5\"}.n_clicks"
+      ],
+      "state": [
+        {
+          "id": {
+            "_id": "inp-0",
+            "_type": "btn5"
+          },
+          "property": "id",
+          "value": {
+            "_id": "inp-0",
+            "_type": "btn5"
+          }
+        }
+      ]
+    },
+    "args": [
+      18,
+      {
+        "_id": "inp-0",
+        "_type": "btn5"
+      }
+    ],
+    "kwargs": {},
+    "result": "pattern MATCH - (18, {'_id': 'inp-0', '_type': 'btn5'})"
+  },
+  {
+    "body": {
+      "output": "{\"_id\":[\"MATCH\"],\"_type\":\"btn5\"}.children",
+      "outputs": {
+        "id": {
+          "_id": "inp-1",
+          "_type": "btn5"
+        },
+        "property": "children"
+      },
+      "inputs": [
+        {
+          "id": {
+            "_id": "inp-1",
+            "_type": "btn5"
+          },
+          "property": "n_clicks",
+          "value": 19
+        }
+      ],
+      "changedPropIds": [
+        "{\"_id\":\"inp-1\",\"_type\":\"btn5\"}.n_clicks"
+      ],
+      "state": [
+        {
+          "id": {
+            "_id": "inp-1",
+            "_type": "btn5"
+          },
+          "property": "id",
+          "value": {
+            "_id": "inp-1",
+            "_type": "btn5"
+          }
+        }
+      ]
+    },
+    "args": [
+      19,
+      {
+        "_id": "inp-1",
+        "_type": "btn5"
+      }
+    ],
+    "kwargs": {},
+    "result": "pattern MATCH - (19, {'_id': 'inp-1', '_type': 'btn5'})"
+  },
+  {
+    "body": {
+      "output": "{\"_id\":[\"MATCH\"],\"_type\":\"btn5\"}.children",
+      "outputs": {
+        "id": {
+          "_id": "inp-2",
+          "_type": "btn5"
+        },
+        "property": "children"
+      },
+      "inputs": [
+        {
+          "id": {
+            "_id": "inp-2",
+            "_type": "btn5"
+          },
+          "property": "n_clicks",
+          "value": 20
+        }
+      ],
+      "changedPropIds": [
+        "{\"_id\":\"inp-2\",\"_type\":\"btn5\"}.n_clicks"
+      ],
+      "state": [
+        {
+          "id": {
+            "_id": "inp-2",
+            "_type": "btn5"
+          },
+          "property": "id",
+          "value": {
+            "_id": "inp-2",
+            "_type": "btn5"
+          }
+        }
+      ]
+    },
+    "args": [
+      20,
+      {
+        "_id": "inp-2",
+        "_type": "btn5"
+      }
+    ],
+    "kwargs": {},
+    "result": "pattern MATCH - (20, {'_id': 'inp-2', '_type': 'btn5'})"
   }
 ]

--- a/django_plotly_dash/tests_dash_contract.py
+++ b/django_plotly_dash/tests_dash_contract.py
@@ -92,6 +92,21 @@ def fill_in_test_app(app: Union[DjangoDash, Dash], write=False):
         def test_multi_output(*args):
             return [f"multi in list - {args}"] * 2
 
+    def add_update_state_in_output():
+        inp1b = html.Button("Input-update-output-state", id="inp1b")
+        out1b = html.A(href="http://www.example.com/null", id="out1b")
+
+        app.layout.children.append(html.Div([inp1b, out1b]))
+
+        @app.callback(
+            [Output(out1b.id, "href"), Output(out1b.id, "children"), ],
+            [Input(inp1b.id, "n_clicks_timestamp")],
+        )
+        @log_body_response
+        def test_update_output_state(n_clicks_timestamp):
+            return f"http://www.example.com/{n_clicks_timestamp}", f"http://www.example.com/{n_clicks_timestamp}"
+
+
     def add_multi_triggered():
         """Test a callback getting more than one element in the triggered context"""
         inp1 = html.Button("Multiple triggered", id="inp2")
@@ -178,6 +193,7 @@ def fill_in_test_app(app: Union[DjangoDash, Dash], write=False):
 
     app.layout = html.Div([])
     add_outputs_multi()
+    add_update_state_in_output()
     add_multi_triggered()
     add_pattern_all()
     add_pattern_allsmaller()


### PR DESCRIPTION
- update test to cover updating state via output
- add lazy parsing of json response

In case we have a DashApp with state to save, the json output of the response is always parsed (json str -> dict) even though sometimes it is not used as the output are not in the da.current_state(). This PR "lazifies" the access to the response keys/values by delaying the `root_value = json.loads(res)` till the first `root_value.get(output_id,{})`.
When returning large figures (that are not saved in the state usually...) in the output, we save the parsing of the json str.