### PR TITLE
fix #328 (initial_arguments broken)

### DIFF
--- a/demo/demo/tests/test_dpd_demo.py
+++ b/demo/demo/tests/test_dpd_demo.py
@@ -22,10 +22,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 '''
+import re
 
 import pytest
-
 from django.urls import reverse
+
 
 @pytest.mark.django_db
 def test_template_tag_use(client):
@@ -38,6 +39,11 @@ def test_template_tag_use(client):
 
         assert response.content
         assert response.status_code == 200
+
+        for src in re.findall('iframe src="(.*?)"', response.content.decode("utf-8")):
+            response = client.get(src + "_dash-layout")
+            assert response.status_code == 200, ""
+
 
 @pytest.mark.django_db
 def test_add_to_session(client):

--- a/django_plotly_dash/util.py
+++ b/django_plotly_dash/util.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 '''
-
+import json
 import uuid
 
 from django.conf import settings
@@ -74,6 +74,10 @@ def store_initial_arguments(request, initial_arguments=None):
 
     if initial_arguments is None:
         return None
+
+    # convert to dict is json string
+    if isinstance(initial_arguments, str):
+        initial_arguments = json.loads(initial_arguments)
 
     # Generate a cache id
     cache_id = "dpd-initial-args-%s" % str(uuid.uuid4()).replace('-', '')


### PR DESCRIPTION
- converting initial_arguments given as json string into a dict in `store_initial_arguments`
- add in the test of the template tag a call to the _dash-layout to ensure the initial_arguments are parsed properly