### PR TITLE
Fixes typo in Configuration.rst

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -32,7 +32,7 @@ below.
       "cache_arguments": True,
 
       # Flag controlling local serving of assets
-      "serve_locally': False,
+      "serve_locally": False,
   }
 
 Defaults are inserted for missing values. It is also permissible to not have any ``PLOTLY_DASH`` entry in


### PR DESCRIPTION
This fixes a typo for the initial configuration from `"serve_locally': False,` to `"serve_locally": False,`