### PR TITLE
Fix getting stuck at loading

### DIFF
--- a/django_plotly_dash/templates/django_plotly_dash/plotly_app.html
+++ b/django_plotly_dash/templates/django_plotly_dash/plotly_app.html
@@ -1,3 +1,3 @@
 <div style="{{dstyle}}">
-  <iframe src="{{app.base_url}}" style="{{istyle}}" frameborder="{{fbs}}" sandbox="allow-downloads"></iframe>
+  <iframe src="{{app.base_url}}" style="{{istyle}}" frameborder="{{fbs}}" sandbox="allow-downloads allow-scripts allow-same-origin"></iframe>
 </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ dpd-components
 dash-bootstrap-components
 
 channels<3.0
-Django>=2.2
+Django>=2.2,<4.0.0
 Flask>=1.0.2


### PR DESCRIPTION
In some demos (see #388) and other applications I'm working on the dash dashboard will never load (tested on an up to date Arch Linux and CentOS 8, using firefox and chrome). When that happens the developer console in the browser tells us the errors are related to the sandboxing. Adding `allow-scripts allow-same-origin` fixes this issue.
While I was doing this, with the default version of the requirements Django 4.0.3 will be installed but at the moment it's not compatible so I'm adding a commit to use the 3.2.12 version instead. This is what one gets when running with Django 4.0.3 after `prepare_demo:`
```
Exception in thread django-main-thread:
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1009, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 946, in run
    self._target(*self._args, **self._kwargs)
  File "/home/user/Test/django-plotly-dash/env/lib/python3.10/site-packages/django/utils/autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File "/home/user/Test/django-plotly-dash/env/lib/python3.10/site-packages/channels/management/commands/runserver.py", line 69, in inner_run
    self.check(display_num_errors=True)
  File "/home/user/Test/django-plotly-dash/env/lib/python3.10/site-packages/django/core/management/base.py", line 487, in check
    all_issues = checks.run_checks(
  File "/home/user/Test/django-plotly-dash/env/lib/python3.10/site-packages/django/core/checks/registry.py", line 88, in run_checks
    new_errors = check(app_configs=app_configs, databases=databases)
  File "/home/user/Test/django-plotly-dash/env/lib/python3.10/site-packages/django/contrib/staticfiles/checks.py", line 7, in check_finders
    for finder in get_finders():
  File "/home/user/Test/django-plotly-dash/env/lib/python3.10/site-packages/django/contrib/staticfiles/finders.py", line 312, in get_finders
    yield get_finder(finder_path)
  File "/home/user/Test/django-plotly-dash/env/lib/python3.10/site-packages/django/contrib/staticfiles/finders.py", line 326, in get_finder
    return Finder()
  File "/home/user/Test/django-plotly-dash/django_plotly_dash/finders.py", line 156, in __init__
    importlib.import_module(root_urls)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/user/Test/django-plotly-dash/demo/demo/urls.py", line 21, in <module>
    from django.conf.urls import url
ImportError: cannot import name 'url' from 'django.conf.urls' (/home/user/Test/django-plotly-dash/env/lib/python3.10/site-packages/django/conf/urls/__init__.py)
```