### PR TITLE
Fix curl URL for Live Updating demo

### DIFF
--- a/demo/demo/templates/demo_four.html
+++ b/demo/demo/templates/demo_four.html
@@ -63,7 +63,7 @@ only one press per colour per second is processed.
 </p>
 <div class="card bg-light border-dark">
   <div class="card-body">
-    curl http://{%site_root_url%}/dpd/views/poke/ -d'{"channel_name":"live_button_counter","label":"named_counts","value":{"click_colour":"red"}}'
+    curl https://{%site_root_url%}/dpd/views/poke/ -d'{"channel_name":"live_button_counter","label":"named_counts","value":{"click_colour":"red"}}'
   </div>
 </div>
 <p></p>


### PR DESCRIPTION
The page redirects from http to https:

    curl http://djangoplotlydash.com/dpd/views/poke/ -d'{"channel_name":"live_button_counter","label":"named_counts","value":{"click_colour":"red"}}'

    <html>
    <head><title>301 Moved Permanently</title></head>
    <body bgcolor="white">
    <center><h1>301 Moved Permanently</h1></center>
    <hr><center>nginx/1.10.3 (Ubuntu)</center>
    </body>
    </html>