### PR TITLE
Update readme - namespace in urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Then, add `django_plotly_dash` to `INSTALLED_APPS` in your Django `settings.py` 
         ]
 
 The application's routes need to be registered within the routing structure by an appropriate ``include`` statement in
-a ``urls.py`` file:
+a ``urls.py`` file. Note: `django_plotly_dash` is not a name of your application, it is referencing the inner namespace of this library. Please do not skip this step:
 
     urlpatterns = [
         ...

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Then, add `django_plotly_dash` to `INSTALLED_APPS` in your Django `settings.py` 
         ]
 
 The application's routes need to be registered within the routing structure by an appropriate ``include`` statement in
-a ``urls.py`` file. Note: `django_plotly_dash` is not a name of your application, it is referencing the inner namespace of this library. Please do not skip this step:
+a ``urls.py`` file. Note: `django_plotly_dash` is not a name of your application, it is referring to the inner namespace of this library. Please do not skip this step:
 
     urlpatterns = [
         ...


### PR DESCRIPTION
Updated Installation part of readme - put an emphasis on adding url namespace to the app urls.
This is due to the fact that [this issue](https://github.com/GibbsConsulting/django-plotly-dash/issues/117) seems to be pretty common throughout first-time users.
