### PR TITLE
Avoid 500 Internal Server Error if empty body is posted to _dash-update_component

### DIFF
--- a/django_plotly_dash/views.py
+++ b/django_plotly_dash/views.py
@@ -83,7 +83,7 @@ def _update(request, ident, stateless=False, **kwargs):
     try:
         request_body = json.loads(request.body.decode('utf-8'))
     except (JSONDecodeError, UnicodeDecodeError):
-        return HttpResponse(status=400)
+        return HttpResponse(status=200)
 
     # Use direct dispatch with extra arguments in the argMap
     app_state = request.session.get("django_plotly_dash", dict())

--- a/django_plotly_dash/views.py
+++ b/django_plotly_dash/views.py
@@ -25,6 +25,7 @@ SOFTWARE.
  # pylint: disable=unused-argument
 
 import json
+from json import JSONDecodeError
 
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import redirect
@@ -79,7 +80,10 @@ def _update(request, ident, stateless=False, **kwargs):
     'Generate update json response'
     dash_app, app = DashApp.locate_item(ident, stateless)
 
-    request_body = json.loads(request.body.decode('utf-8'))
+    try:
+        request_body = json.loads(request.body.decode('utf-8'))
+    except (JSONDecodeError, UnicodeDecodeError):
+        return HttpResponse(status=400)
 
     # Use direct dispatch with extra arguments in the argMap
     app_state = request.session.get("django_plotly_dash", dict())


### PR DESCRIPTION
# Bug
Requests with an empty body to the endpoint `_dash-update-component` are triggering an *500 Internal Server error* response. This issue has been observed in operational practice, web crawlers seem to pick up this endpoint and send a request with an empty body. Consequently, the cloud environment reports *500 Internal Server* errors.

This can be reproduced with the *Demo Four* app in this repository. Just send this request:

```
GET http://127.0.0.1:8000/django_plotly_dash/app/LiveInput/_dash-update-component
Accept: application/json
```

We get:
```
GET http://127.0.0.1:8000/django_plotly_dash/app/LiveInput/_dash-update-component

HTTP/1.1 500 Internal Server Error
```

# Expected behavior
The endpoint should respond with a *400 Bad Request* error.

# Fix
The error occurs because the JSON deserialization of the empty (or otherwise invalid) body is failing, and this exception is not caught. It should be possible to simply catch the exceptions that can be thrown in this line.

With the changes in this pull request, we get this response:
```
GET http://127.0.0.1:8000/django_plotly_dash/app/LiveInput/_dash-update-component

HTTP/1.1 400 Bad Request
```

