### PR TITLE
Temporarily restrict Dash version as per #460 #461

### DIFF
--- a/django_plotly_dash/version.py
+++ b/django_plotly_dash/version.py
@@ -23,4 +23,4 @@ SOFTWARE.
 
 '''
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dash>=2.0
+dash>=2.0,<2.10
 plotly
 dpd-components
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     'Documentation': 'http://django-plotly-dash.readthedocs.io/',
     },
     install_requires = ['plotly',
-                        'dash>=2.0',
+                        'dash>=2.0,<2.10',
                         'dpd-components',
 
                         'dash-bootstrap-components',


### PR DESCRIPTION
Short term fix for #460 by limiting the Dash version to less than 2.10
