### PR TITLE
Enable use of channels and Django versions 4.0

### DIFF
--- a/demo/demo/asgi.py
+++ b/demo/demo/asgi.py
@@ -24,10 +24,12 @@ SOFTWARE.
 
 import os
 import django
-from channels.routing import get_default_application
+from channels.routing import get_default_application, ProtocolTypeRouter
+from django.core.asgi import get_asgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "demo.settings")
 
 django.setup()
 
-application = get_default_application()
+from django_plotly_dash.routing import application
+

--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -31,6 +31,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
+    'daphne',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -38,7 +39,6 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
 
-    'channels',
     'bootstrap4',
 
     'django_plotly_dash.apps.DjangoPlotlyDashConfig',
@@ -82,7 +82,7 @@ X_FRAME_OPTIONS = 'SAMEORIGIN'
 
 WSGI_APPLICATION = 'demo.wsgi.application'
 
-ASGI_APPLICATION = 'demo.routing.application'
+ASGI_APPLICATION = 'demo.asgi.application'
 
 # Database
 # https://docs.djangoproject.com/en/2.0/ref/settings/#databases

--- a/django_plotly_dash/routing.py
+++ b/django_plotly_dash/routing.py
@@ -58,3 +58,4 @@ application = ProtocolTypeRouter({
     'websocket': AuthMiddlewareStack(URLRouter([re_path(pipe_ws_endpoint_name(), MessageConsumer if OLDER_CHANNELS else MessageConsumer.as_asgi()),])),
     'http': AuthMiddlewareStack(URLRouter(http_routes)),
 })
+

--- a/django_plotly_dash/version.py
+++ b/django_plotly_dash/version.py
@@ -23,4 +23,4 @@ SOFTWARE.
 
 '''
 
-__version__ = "2.2.2"
+__version__ = "2.3.0"

--- a/prepare_demo
+++ b/prepare_demo
@@ -8,4 +8,5 @@ cd demo
 #
 # Run debug server. Use the nostatic flag to enable the use of whitenose rather than the standard Django debug handling
 #
-./manage.py runserver --nostatic
+#./manage.py runserver --nostatic
+./manage.py runserver 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ dpd-components
 
 dash-bootstrap-components
 
-channels>=2.0
-Django>=3.2,<5.0.0
+channels>=4.0
+Django>=4.0.0
 Flask>=1.0.2
 Werkzeug

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ setup(
 
                         'dash-bootstrap-components',
 
-                        'channels>=2.0',
-                        'Django>=3.2,<5.0.0',
+                        'channels>=4.0',
+                        'Django>=4.0.0',
                         'Flask>=1.0.2',
                         'Werkzeug',
     ],


### PR DESCRIPTION
Enable use of channels and Django versions > 4.0
Provides a working asgi file for this new combination, along with a working (albeit with daphne) runserver for debugging.
