### PR TITLE
Restrict Dash version to less than 2.13

### DIFF
--- a/django_plotly_dash/version.py
+++ b/django_plotly_dash/version.py
@@ -23,4 +23,4 @@ SOFTWARE.
 
 '''
 
-__version__ = "2.4.0"
+__version__ = "2.4.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dash>=2.0,<3.0
+dash>=2.0,<2.13
 plotly
 dpd-components
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     'Documentation': 'http://django-plotly-dash.readthedocs.io/',
     },
     install_requires = ['plotly',
-                        'dash>=2.0,<3.0',
+                        'dash>=2.0,<2.13',
                         'dpd-components',
 
                         'dash-bootstrap-components',


### PR DESCRIPTION
Restrict the version of Dash to less than 2.13
This should provide a temporary fix to #502 
