### PR TITLE
Bump version to 2.4.3

### DIFF
--- a/django_plotly_dash/version.py
+++ b/django_plotly_dash/version.py
@@ -23,4 +23,4 @@ SOFTWARE.
 
 '''
 
-__version__ = "2.4.2"
+__version__ = "2.4.3"


### PR DESCRIPTION
Version 2.4.2. had an unfortunate build artifact. An updated version has been pushed to PyPI, necessitating a bump in package number.
