### PR TITLE
Update dpd to work with dash versions > 3

### DIFF
--- a/django_plotly_dash/dash_wrapper.py
+++ b/django_plotly_dash/dash_wrapper.py
@@ -430,6 +430,7 @@ class WrappedDash(Dash):
 
         kwargs['url_base_pathname'] = self._base_pathname
         kwargs['server'] = self._notflask
+        #kwargs['use_async'] = False
 
         #xkwargs['DEBUG'] = kwargs.get('DEBUG', False)
 
@@ -819,3 +820,12 @@ class WrappedDash(Dash):
     def exit_embedded(self):
         'Exit the embedded section after processing a view'
         self._return_embedded = False
+
+    def __call__(self, *args, **kwargs):
+        """Implement a no-op __call__ method.
+
+        This is needed as dash v3.1.0 adds a __call__ method to the underlying Dash
+        class, and this interferes with the operation of Django templates.
+        """
+        return self
+

--- a/django_plotly_dash/version.py
+++ b/django_plotly_dash/version.py
@@ -23,4 +23,4 @@ SOFTWARE.
 
 '''
 
-__version__ = "2.4.7"
+__version__ = "2.5.0"

--- a/pylintrc
+++ b/pylintrc
@@ -319,12 +319,6 @@ max-line-length=100
 # Maximum number of lines in a module
 max-module-lines=1000
 
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.
@@ -475,4 +469,4 @@ known-third-party=enchant
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dash>=2.0,<3.0
+dash>=3.0
 plotly
 dpd-components
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-dash>=3.0
+dash>=2.0
 plotly
-dpd-components
+dpd-components>=0.2.0
 
 dash-bootstrap-components
 

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,10 @@ setup(
     'Documentation': 'http://django-plotly-dash.readthedocs.io/',
     },
     install_requires = ['plotly',
-                        'dash>=3.0',
+                        'dash>=2.0',
                         'dpd-components',
 
-                        'dash-bootstrap-components',
+                        'dash-bootstrap-components>=0.2.0',
 
                         'channels>=4.0',
                         'Django>=4.0.0',

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     'Documentation': 'http://django-plotly-dash.readthedocs.io/',
     },
     install_requires = ['plotly',
-                        'dash>=2.0,<3.0',
+                        'dash>=3.0',
                         'dpd-components',
 
                         'dash-bootstrap-components',

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,9 @@ setup(
     },
     install_requires = ['plotly',
                         'dash>=2.0',
-                        'dpd-components',
+                        'dpd-components>=0.2.0',
 
-                        'dash-bootstrap-components>=0.2.0',
+                        'dash-bootstrap-components',
 
                         'channels>=4.0',
                         'Django>=4.0.0',


### PR DESCRIPTION
Changes to make the package work with Dash versions >= 3.0
These changes enable the package to work, but do not necessarily allow all new features in Dash 3.0 to work.
