### PR TITLE
Fixed prepare_redis script

### DIFF
--- a/prepare_redis
+++ b/prepare_redis
@@ -6,5 +6,5 @@
 # Also, the use of redis is driven by the configuration of the channels project; changing the CHANNEL_LAYERS
 # setting will directly impact and even remove the need for redis
 #
-docker pull redis:4
-docker run -p 6379:6379 -d redis
+
+docker run --rm --pull missing -p 6379:6379 -d redis:latest


### PR DESCRIPTION
This PR fixes some problems with `prepare_redis` script:
- there is explicit pulling of version 4, but `latest` version is running and pulls again
- added `--rm` to automatically remove container after stop